### PR TITLE
Pull request comments API

### DIFF
--- a/src/main/java/com/cdancy/bitbucket/rest/domain/branch/Type.java
+++ b/src/main/java/com/cdancy/bitbucket/rest/domain/branch/Type.java
@@ -17,13 +17,9 @@
 
 package com.cdancy.bitbucket.rest.domain.branch;
 
-import com.cdancy.bitbucket.rest.error.Error;
-import com.google.auto.value.AutoValue;
-import com.google.common.collect.ImmutableList;
-import org.jclouds.javax.annotation.Nullable;
 import org.jclouds.json.SerializedNames;
 
-import java.util.List;
+import com.google.auto.value.AutoValue;
 
 @AutoValue
 public abstract class Type {

--- a/src/main/java/com/cdancy/bitbucket/rest/domain/repository/Repository.java
+++ b/src/main/java/com/cdancy/bitbucket/rest/domain/repository/Repository.java
@@ -17,16 +17,16 @@
 
 package com.cdancy.bitbucket.rest.domain.repository;
 
-import com.cdancy.bitbucket.rest.domain.project.Project;
-import com.cdancy.bitbucket.rest.domain.pullrequest.Links;
-import com.cdancy.bitbucket.rest.domain.pullrequest.ProjectKey;
-import com.cdancy.bitbucket.rest.error.Error;
-import com.google.auto.value.AutoValue;
-import com.google.common.collect.ImmutableList;
+import java.util.List;
+
 import org.jclouds.javax.annotation.Nullable;
 import org.jclouds.json.SerializedNames;
 
-import java.util.List;
+import com.cdancy.bitbucket.rest.domain.project.Project;
+import com.cdancy.bitbucket.rest.domain.pullrequest.Links;
+import com.cdancy.bitbucket.rest.error.Error;
+import com.google.auto.value.AutoValue;
+import com.google.common.collect.ImmutableList;
 
 @AutoValue
 public abstract class Repository {

--- a/src/main/java/com/cdancy/bitbucket/rest/options/CreateRepository.java
+++ b/src/main/java/com/cdancy/bitbucket/rest/options/CreateRepository.java
@@ -17,9 +17,9 @@
 
 package com.cdancy.bitbucket.rest.options;
 
-import com.google.auto.value.AutoValue;
-import org.jclouds.javax.annotation.Nullable;
 import org.jclouds.json.SerializedNames;
+
+import com.google.auto.value.AutoValue;
 
 @AutoValue
 public abstract class CreateRepository {

--- a/src/test/java/com/cdancy/bitbucket/rest/features/BranchApiMockTest.java
+++ b/src/test/java/com/cdancy/bitbucket/rest/features/BranchApiMockTest.java
@@ -17,20 +17,19 @@
 
 package com.cdancy.bitbucket.rest.features;
 
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+
+import org.testng.annotations.Test;
+
 import com.cdancy.bitbucket.rest.BitbucketApi;
 import com.cdancy.bitbucket.rest.BitbucketApiMetadata;
 import com.cdancy.bitbucket.rest.domain.branch.Branch;
 import com.cdancy.bitbucket.rest.domain.branch.BranchModel;
-import com.cdancy.bitbucket.rest.domain.tags.Tag;
 import com.cdancy.bitbucket.rest.internal.BaseBitbucketMockTest;
 import com.cdancy.bitbucket.rest.options.CreateBranch;
-import com.cdancy.bitbucket.rest.options.CreateTag;
 import com.squareup.okhttp.mockwebserver.MockResponse;
 import com.squareup.okhttp.mockwebserver.MockWebServer;
-import org.testng.annotations.Test;
-
-import static org.testng.Assert.assertNotNull;
-import static org.testng.Assert.assertTrue;
 
 /**
  * Mock tests for the {@link BranchApi} class.

--- a/src/test/java/com/cdancy/bitbucket/rest/features/RepositoryApiMockTest.java
+++ b/src/test/java/com/cdancy/bitbucket/rest/features/RepositoryApiMockTest.java
@@ -17,6 +17,11 @@
 
 package com.cdancy.bitbucket.rest.features;
 
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+
+import org.testng.annotations.Test;
+
 import com.cdancy.bitbucket.rest.BitbucketApi;
 import com.cdancy.bitbucket.rest.BitbucketApiMetadata;
 import com.cdancy.bitbucket.rest.domain.repository.Repository;
@@ -24,10 +29,6 @@ import com.cdancy.bitbucket.rest.internal.BaseBitbucketMockTest;
 import com.cdancy.bitbucket.rest.options.CreateRepository;
 import com.squareup.okhttp.mockwebserver.MockResponse;
 import com.squareup.okhttp.mockwebserver.MockWebServer;
-import org.testng.annotations.Test;
-
-import static org.testng.Assert.assertNotNull;
-import static org.testng.Assert.assertTrue;
 
 /**
  * Mock tests for the {@link RepositoryApi} class.
@@ -85,7 +86,6 @@ public class RepositoryApiMockTest extends BaseBitbucketMockTest {
         try {
             String projectKey = "PRJ";
             String repoKey = "myrepo";
-            CreateRepository createRepository = CreateRepository.create(repoKey, true);
             Repository repository = api.get(projectKey, repoKey);
             assertNotNull(repository);
             assertTrue(repository.errors().size() == 0);
@@ -106,7 +106,6 @@ public class RepositoryApiMockTest extends BaseBitbucketMockTest {
         try {
             String projectKey = "PRJ";
             String repoKey = "notexist";
-            CreateRepository createRepository = CreateRepository.create(repoKey, true);
             Repository repository = api.get(projectKey, repoKey);
             assertNotNull(repository);
             assertTrue(repository.errors().size() == 1);


### PR DESCRIPTION
 * Only GET, DELETE and POST method implemented.
 * Changing BitbucketFallbacks.getErrors() so that it throws the original throwable. It was lost when the original errors was not a JSON object. Then a new InvocationTargetException occured and was thrown, and the original throwable lost.
 * Using Java Method Invocation Builder on API:s to create invocation builders. Making client code cleaner.
 * Using AssertJ and changing some assertions to show the actual failure reason.