### PR TITLE
Fix to account for Bitbucket not handing back a list of 'error' objects.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -108,7 +108,7 @@ task integTest(type: Test, dependsOn: ['mockTest']) {
         }
     }
     useTestNG() 
-    include '**/BitbucketClientLiveTest.class'
+    include '**/**LiveTest.class'
     testLogging {
         showStandardStreams = true
         events 'started', 'passed', 'failed'

--- a/src/test/resources/admin-list-user-by-group-error.json
+++ b/src/test/resources/admin-list-user-by-group-error.json
@@ -1,9 +1,5 @@
-{
-  "errors": [
-    {
-      "context": null,
-      "exceptionName": null,
-      "message": "The context parameter is required."
-    }
-  ]
+{  
+   "context":null,
+   "message":"You are not permitted to access this resource",
+   "exceptionName":"com.atlassian.bitbucket.AuthorisationException"
 }


### PR DESCRIPTION
@martinda take a look at this PR and let me know what you think. Just whipped it up but it _should_ solve the problem. We will check if the returned json contains `errors` (i.e. meaning a list) then check for a single `error` and then fallback to the defaults.