### PR TITLE
CreateUser, DeleteUser and AddParticipant endpoints

### DIFF
--- a/src/main/java/com/cdancy/bitbucket/rest/domain/pullrequest/User.java
+++ b/src/main/java/com/cdancy/bitbucket/rest/domain/pullrequest/User.java
@@ -17,48 +17,75 @@
 
 package com.cdancy.bitbucket.rest.domain.pullrequest;
 
-import org.jclouds.json.SerializedNames;
-
+import com.cdancy.bitbucket.rest.BitbucketUtils;
+import com.cdancy.bitbucket.rest.domain.common.Error;
+import com.cdancy.bitbucket.rest.domain.common.ErrorsHolder;
 import com.google.auto.value.AutoValue;
 import org.jclouds.javax.annotation.Nullable;
+import org.jclouds.json.SerializedNames;
+
+import java.util.Collections;
+import java.util.List;
 
 @AutoValue
-public abstract class User {
+public abstract class User implements ErrorsHolder {
 
+    @Nullable
     public abstract String name();
 
     @Nullable
     public abstract String emailAddress();
 
-    public abstract int id();
+    @Nullable
+    public abstract Integer id();
 
+    @Nullable
     public abstract String displayName();
 
-    public abstract boolean active();
+    @Nullable
+    public abstract Boolean active();
 
+    @Nullable
     public abstract String slug();
 
+    @Nullable
     public abstract String type();
+
+    @Nullable
+    public abstract String directoryName();
+
+    @Nullable
+    public abstract Boolean deletable();
+
+    @Nullable
+    public abstract Long lastAuthenticationTimestamp();
+
+    @Nullable
+    public abstract Boolean mutableDetails();
+
+    @Nullable
+    public abstract Boolean mutableGroups();
 
     User() {
     }
 
-    @SerializedNames({ "name", "emailAddress", "id", 
-            "displayName", "active", "slug", "type" })
-    public static User create(final String name, 
-            final String emailAddress, 
-            final int id,
-            final String displayName, 
-            final boolean active, 
-            final String slug, 
-            final String type) {
-        
-        return new AutoValue_User(name, 
-                emailAddress, 
-                id, 
-                displayName, 
-                active, 
-                slug, 
-                type);
+    @SerializedNames({ "name", "emailAddress", "id", "displayName", "active", "slug", "type" })
+    public static User create(final String name, final String emailAddress, final int id, final String displayName,
+                              final boolean active, final String slug, final String type) {
+
+        return new AutoValue_User(Collections.emptyList(), name, emailAddress, id, displayName, active, slug, type,
+            null, null, null, null, null);
+    }
+
+    @SerializedNames({ "errors", "name", "emailAddress", "id", "displayName", "active", "slug", "type", "directoryName",
+            "deletable", "lastAuthenticationTimestamp", "mutableDetails", "mutableGroups" })
+    public static User create(final List<Error> errors, final String name, final String emailAddress, final int id,
+                              final String displayName, final boolean active, final String slug, final String type,
+                              final String directoryName, final boolean deletable,
+                              final long lastAuthenticationTimestamp, final boolean mutableDetails,
+                              final boolean mutableGroups) {
+
+        return new AutoValue_User(BitbucketUtils.nullToEmpty(errors), name, emailAddress, id, displayName,
+            active, slug, type, directoryName, deletable, lastAuthenticationTimestamp, mutableDetails, mutableGroups);
     }
 }

--- a/src/main/java/com/cdancy/bitbucket/rest/fallbacks/BitbucketFallbacks.java
+++ b/src/main/java/com/cdancy/bitbucket/rest/fallbacks/BitbucketFallbacks.java
@@ -51,6 +51,7 @@ import com.cdancy.bitbucket.rest.domain.pullrequest.CommentPage;
 import com.cdancy.bitbucket.rest.domain.pullrequest.MergeStatus;
 import com.cdancy.bitbucket.rest.domain.pullrequest.PullRequest;
 import com.cdancy.bitbucket.rest.domain.pullrequest.PullRequestPage;
+import com.cdancy.bitbucket.rest.domain.pullrequest.User;
 import com.cdancy.bitbucket.rest.domain.repository.Hook;
 import com.cdancy.bitbucket.rest.domain.repository.HookPage;
 import com.cdancy.bitbucket.rest.domain.repository.HookSettings;
@@ -129,6 +130,16 @@ public final class BitbucketFallbacks {
         public Object createOrPropagate(final Throwable throwable) throws Exception {
             if (checkNotNull(throwable, "throwable") != null) {
                 return createUserPageFromErrors(getErrors(throwable.getMessage()));
+            }
+            throw propagate(throwable);
+        }
+    }
+
+    public static final class UserOnError implements Fallback<Object> {
+        @Override
+        public Object createOrPropagate(final Throwable throwable) throws Exception {
+            if (checkNotNull(throwable, "throwable") != null) {
+                return createUserFromErrors(getErrors(throwable.getMessage()));
             }
             throw propagate(throwable);
         }
@@ -478,6 +489,10 @@ public final class BitbucketFallbacks {
         return UserPage.create(-1, -1, -1, -1, true, null, errors);
     }
 
+    public static User createUserFromErrors(final List<Error> errors) {
+        return User.create(errors, null, null, -1, null, false, null, null, null, false, -1, false, false);
+    }
+
     public static Condition createConditionFromErrors(final List<Error> errors) {
         return Condition.create(null, null, null, null, null, null, errors);
     }
@@ -629,7 +644,7 @@ public final class BitbucketFallbacks {
 
     /**
      * Parse a single Error object from a given JsonObject.
-     * 
+     *
      * @param obj the JsonObject to parse an Error from.
      * @return Error object derived from parsing the passed JsonObject.
      */

--- a/src/main/java/com/cdancy/bitbucket/rest/features/AdminApi.java
+++ b/src/main/java/com/cdancy/bitbucket/rest/features/AdminApi.java
@@ -19,16 +19,22 @@ package com.cdancy.bitbucket.rest.features;
 
 import com.cdancy.bitbucket.rest.annotations.Documentation;
 import com.cdancy.bitbucket.rest.domain.admin.UserPage;
+import com.cdancy.bitbucket.rest.domain.common.RequestStatus;
+import com.cdancy.bitbucket.rest.domain.pullrequest.User;
 import com.cdancy.bitbucket.rest.fallbacks.BitbucketFallbacks;
 import com.cdancy.bitbucket.rest.filters.BitbucketAuthenticationFilter;
+import com.cdancy.bitbucket.rest.parsers.RequestStatusParser;
 import org.jclouds.javax.annotation.Nullable;
 import org.jclouds.rest.annotations.Fallback;
 import org.jclouds.rest.annotations.RequestFilters;
+import org.jclouds.rest.annotations.ResponseParser;
 
 import javax.inject.Named;
 import javax.ws.rs.Consumes;
+import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
+import javax.ws.rs.POST;
 import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
@@ -46,10 +52,10 @@ public interface AdminApi {
     @Fallback(BitbucketFallbacks.UserPageOnError.class)
     @GET
     UserPage listUsersByGroup(@QueryParam("context") String context,
-                             @Nullable @QueryParam("filter") String filter,
-                             @Nullable @QueryParam("start") Integer start,
-                             @Nullable @QueryParam("limit") Integer limit);
-    
+                              @Nullable @QueryParam("filter") String filter,
+                              @Nullable @QueryParam("start") Integer start,
+                              @Nullable @QueryParam("limit") Integer limit);
+
     @Named("admin:list-users")
     @Documentation({"https://developer.atlassian.com/static/rest/bitbucket-server/latest/bitbucket-rest.html#idm45588158982432"})
     @Consumes(MediaType.APPLICATION_JSON)
@@ -57,6 +63,28 @@ public interface AdminApi {
     @Fallback(BitbucketFallbacks.UserPageOnError.class)
     @GET
     UserPage listUsers(@Nullable @QueryParam("filter") String filter,
-                        @Nullable @QueryParam("start") Integer start,
-                        @Nullable @QueryParam("limit") Integer limit);
+                       @Nullable @QueryParam("start") Integer start,
+                       @Nullable @QueryParam("limit") Integer limit);
+
+    @Named("admin:create-user")
+    @Documentation({"https://developer.atlassian.com/static/rest/bitbucket-server/latest/bitbucket-rest.html#idm46358291368432"})
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Path("/users")
+    @Fallback(BitbucketFallbacks.RequestStatusOnError.class)
+    @ResponseParser(RequestStatusParser.class)
+    @POST
+    RequestStatus createUser(@QueryParam("name") String name,
+                             @QueryParam("password") String password,
+                             @QueryParam("displayName") String displayName,
+                             @QueryParam("emailAddress") String emailAddress,
+                             @Nullable @QueryParam("addToDefaultGroup") Boolean addToDefaultGroup,
+                             @Nullable @QueryParam("notify") String notify);
+
+    @Named("admin:delete-user")
+    @Documentation({"https://developer.atlassian.com/static/rest/bitbucket-server/latest/bitbucket-rest.html#idm46358291356736"})
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Path("/users")
+    @Fallback(BitbucketFallbacks.UserOnError.class)
+    @DELETE
+    User deleteUser(@QueryParam("name") String name);
 }

--- a/src/main/java/com/cdancy/bitbucket/rest/features/PullRequestApi.java
+++ b/src/main/java/com/cdancy/bitbucket/rest/features/PullRequestApi.java
@@ -25,6 +25,7 @@ import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
+import javax.ws.rs.PUT;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 
@@ -217,4 +218,16 @@ public interface PullRequestApi {
                                @PathParam("repo") String repo,
                                @PathParam("pullRequestId") long pullRequestId,
                                @PathParam("userSlug") String userSlug);
+
+    @Named("pull-request:add-participant")
+    @Documentation({"https://developer.atlassian.com/static/rest/bitbucket-server/latest/bitbucket-rest.html#idm46358292595040"})
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Path("/{project}/repos/{repo}/pull-requests/{pullRequestId}/participants/{userSlug}")
+    @Fallback(ParticipantsOnError.class)
+    @PUT
+    Participants addParticipant(@PathParam("project") String project,
+                                 @PathParam("repo") String repo,
+                                 @PathParam("pullRequestId") long pullRequestId,
+                                 @PathParam("userSlug") String userSlug,
+                                 @BinderParam(BindToJsonPayload.class) CreateParticipants participants);
 }

--- a/src/test/java/com/cdancy/bitbucket/rest/TestUtilities.java
+++ b/src/test/java/com/cdancy/bitbucket/rest/TestUtilities.java
@@ -61,7 +61,7 @@ public class TestUtilities extends BitbucketUtils {
     /**
      * Get the default User from the passed credential String. Once user
      * is found we will cache for later usage.
-     * 
+     *
      * @param api Bitbucket api object.
      * @param auth the BitbucketAuthentication instance.
      * @return User or null if user can't be inferred.
@@ -88,10 +88,10 @@ public class TestUtilities extends BitbucketUtils {
 
         return defaultUser;
     }
-    
+
     /**
      * Execute `args` at the `workingDir`.
-     * 
+     *
      * @param args list of arguments to pass to Process.
      * @param workingDir directory to execute Process within.
      * @return possible output of Process.
@@ -101,17 +101,17 @@ public class TestUtilities extends BitbucketUtils {
         assertThat(args).isNotNull().isNotEmpty();
         assertThat(workingDir).isNotNull();
         assertThat(workingDir.toFile().isDirectory()).isTrue();
-        
+
         final Process process = new ProcessBuilder(args)
                 .directory(workingDir.toFile())
                 .start();
 
         return Strings2.toStringAndClose(process.getInputStream());
     }
-    
+
     /**
      * Generate a dummy file at the `baseDir` location.
-     * 
+     *
      * @param baseDir directory to generate the file under.
      * @return Path pointing at generated file.
      * @throws Exception if file could not be written.
@@ -119,35 +119,35 @@ public class TestUtilities extends BitbucketUtils {
     public static Path initGeneratedFile(final Path baseDir) throws Exception {
         assertThat(baseDir).isNotNull();
         assertThat(baseDir.toFile().isDirectory()).isTrue();
-        
+
         final String randomName = randomString();
-        
+
         final List<String> lines = Arrays.asList(randomName);
         final Path file = Paths.get(new File(baseDir.toFile(), randomName + ".txt").toURI());
-        return Files.write(file, lines, Charset.forName("UTF-8"));        
+        return Files.write(file, lines, Charset.forName("UTF-8"));
     }
-    
+
     /**
      * Initialize live test contents.
-     * 
+     *
      * @param endpoint Bitbucket endpoint.
      * @param credential Bitbucket credential string.
      * @param api Bitbucket api object.
      * @return GeneratedTestContents to use.
      */
-    public static synchronized GeneratedTestContents initGeneratedTestContents(final String endpoint, 
-                                                                                final BitbucketAuthentication credential, 
+    public static synchronized GeneratedTestContents initGeneratedTestContents(final String endpoint,
+                                                                                final BitbucketAuthentication credential,
                                                                                 final BitbucketApi api) {
         assertThat(endpoint).isNotNull();
         assertThat(credential).isNotNull();
         assertThat(api).isNotNull();
-                
+
         // get possibly existing projectKey that user passed in
         String projectKey = System.getProperty("test.bitbucket.project");
         if (projectKey == null) {
             projectKey = randomStringLettersOnly();
         }
-            
+
         // create test project if one does not already exist
         boolean projectPreviouslyExists = true;
         Project project = api.projectApi().get(projectKey);
@@ -159,16 +159,16 @@ public class TestUtilities extends BitbucketUtils {
             final CreateProject createProject = CreateProject.create(projectKey, null, null, null);
             project = api.projectApi().create(createProject);
             assertThat(project).isNotNull();
-            assertThat(project.errors().isEmpty()).isTrue();    
+            assertThat(project.errors().isEmpty()).isTrue();
         }
-        
+
         // create test repo
         final String repoKey = randomStringLettersOnly();
         final CreateRepository createRepository = CreateRepository.create(repoKey, true);
         final Repository repository = api.repositoryApi().create(projectKey, createRepository);
         assertThat(repository).isNotNull();
         assertThat(repository.errors().isEmpty()).isTrue();
-        
+
         final Path testDir = Paths.get(System.getProperty("test.bitbucket.basedir"));
         assertThat(testDir.toFile().exists()).isTrue();
         assertThat(testDir.toFile().isDirectory()).isTrue();
@@ -176,42 +176,42 @@ public class TestUtilities extends BitbucketUtils {
         final String randomName = randomString();
         final File generatedFileDir = new File(testDir.toFile(), randomName);
         assertThat(generatedFileDir.mkdirs()).isTrue();
-        
+
         try {
             final String foundCredential = getDefaultUser(credential, api).slug();
             final URL endpointURL = new URL(endpoint);
             final int index = endpointURL.toString().indexOf(endpointURL.getHost());
             final String preCredentialPart = endpointURL.toString().substring(0, index);
             final String postCredentialPart = endpointURL.toString().substring(index, endpointURL.toString().length());
-        
-            final String generatedEndpoint = preCredentialPart 
-                    + foundCredential + "@" 
-                    + postCredentialPart + "/scm/" 
-                    + projectKey.toLowerCase() + "/" 
+
+            final String generatedEndpoint = preCredentialPart
+                    + foundCredential + "@"
+                    + postCredentialPart + "/scm/"
+                    + projectKey.toLowerCase() + "/"
                     + repoKey.toLowerCase() + ".git";
 
             generateGitContentsAndPush(generatedFileDir, generatedEndpoint);
-            
+
         } catch (final Exception e) {
             throw Throwables.propagate(e);
         }
-        
-        return new GeneratedTestContents(project, repository, projectPreviouslyExists);        
+
+        return new GeneratedTestContents(project, repository, projectPreviouslyExists);
     }
-    
+
     /**
      * Initialize git repository and add some randomly generated files.
-     * 
+     *
      * @param gitDirectory directory to initialize and create files within.
      * @param gitRepoURL git repository URL with embedded credentials.
      * @throws Exception if git repository could not be created or files added.
      */
     public static void generateGitContentsAndPush(final File gitDirectory, final String gitRepoURL) throws Exception {
-        
+
         // 1.) initialize git repository
         final String initGit = TestUtilities.executionToString(Arrays.asList(GIT_COMMAND, "init"), gitDirectory.toPath());
         System.out.println("git-init: " + initGit.trim());
-        
+
         // 2.) create some random files and commit them
         for (int i = 0; i < 3; i++) {
             Path genFile = initGeneratedFile(gitDirectory.toPath());
@@ -219,7 +219,7 @@ public class TestUtilities extends BitbucketUtils {
             System.out.println("git-add-1: " + addGit.trim());
             String commitGit = TestUtilities.executionToString(Arrays.asList(GIT_COMMAND, "commit", "-m", "added"), gitDirectory.toPath());
             System.out.println("git-commit-1: " + commitGit.trim());
-            
+
             // edit file again and create another commit
             genFile = Files.write(genFile, Arrays.asList(randomString()), Charset.forName("UTF-8"));
             addGit = TestUtilities.executionToString(Arrays.asList(GIT_COMMAND, "add", genFile.toFile().getPath()), gitDirectory.toPath());
@@ -231,57 +231,57 @@ public class TestUtilities extends BitbucketUtils {
                             .asList(GIT_COMMAND, "tag", "-a", "v0.0." + (i + 1), "-m", "\"generated version\""), gitDirectory.toPath());
             System.out.println("git-tag-commit: " + tagGit.trim());
         }
-        
+
         // 3.) push changes to remote repository
-        final String pushGit = TestUtilities.executionToString(Arrays.asList(GIT_COMMAND, 
-                "push", 
-                "--set-upstream", 
-                gitRepoURL, 
+        final String pushGit = TestUtilities.executionToString(Arrays.asList(GIT_COMMAND,
+                "push",
+                "--set-upstream",
+                gitRepoURL,
                 "master"), gitDirectory.toPath());
         System.out.println("git-push: " + pushGit);
-        
-        // 4.) create branch 
+
+        // 4.) create branch
         final String generatedBranchName = randomString();
-        final String branchGit = TestUtilities.executionToString(Arrays.asList(GIT_COMMAND, 
-                "checkout", "-b", 
-                generatedBranchName), 
+        final String branchGit = TestUtilities.executionToString(Arrays.asList(GIT_COMMAND,
+                "checkout", "-b",
+                generatedBranchName),
                 gitDirectory.toPath());
         System.out.println("git-branch: " + branchGit.trim());
 
-        
+
         // 5.) generate random file for new branch
         final Path genFile = initGeneratedFile(gitDirectory.toPath());
         final String addGit = TestUtilities.executionToString(Arrays.asList(GIT_COMMAND, "add", genFile.toFile().getPath()), gitDirectory.toPath());
         System.out.println("git-branch-add: " + addGit.trim());
         final String commitGit = TestUtilities.executionToString(Arrays.asList(GIT_COMMAND, "commit", "-m", "added"), gitDirectory.toPath());
         System.out.println("git-branch-commit: " + commitGit.trim());
-        
+
         // 6.) push branch
         final List<String> args = Arrays.asList(GIT_COMMAND, "push", "--tags", "-u", gitRepoURL, generatedBranchName);
         final String pushBranchGit = TestUtilities.executionToString(args, gitDirectory.toPath());
         System.out.println("git-branch-push: " + pushBranchGit);
     }
-    
+
     /**
      * Terminate live test contents.
-     * 
+     *
      * @param api BitbucketApi object
      * @param generatedTestContents to terminate.
      */
-    public static synchronized void terminateGeneratedTestContents(final BitbucketApi api, 
+    public static synchronized void terminateGeneratedTestContents(final BitbucketApi api,
             final GeneratedTestContents generatedTestContents) {
         assertThat(api).isNotNull();
         assertThat(generatedTestContents).isNotNull();
-        
+
         final Project project = generatedTestContents.project;
         final Repository repository = generatedTestContents.repository;
-        
-        // delete repository 
+
+        // delete repository
         final RequestStatus success = api.repositoryApi().delete(project.key(), repository.name());
         assertThat(success).isNotNull();
         assertThat(success.value()).isTrue();
         assertThat(success.errors()).isEmpty();
-            
+
         // delete project
         if (!generatedTestContents.projectPreviouslyExists) {
             final RequestStatus deleteStatus = api.projectApi().delete(project.key());
@@ -290,10 +290,10 @@ public class TestUtilities extends BitbucketUtils {
             assertThat(deleteStatus.errors()).isEmpty();
         }
     }
-    
+
     /**
      * Generate a random String with letters only.
-     * 
+     *
      * @return random String.
      */
     public static String randomStringLettersOnly() {
@@ -308,7 +308,7 @@ public class TestUtilities extends BitbucketUtils {
 
     /**
      * Generate a random String with numbers and letters.
-     * 
+     *
      * @return random String.
      */
     public static String randomString() {

--- a/src/test/java/com/cdancy/bitbucket/rest/features/AdminApiLiveTest.java
+++ b/src/test/java/com/cdancy/bitbucket/rest/features/AdminApiLiveTest.java
@@ -20,6 +20,7 @@ package com.cdancy.bitbucket.rest.features;
 import com.cdancy.bitbucket.rest.BaseBitbucketApiLiveTest;
 import com.cdancy.bitbucket.rest.TestUtilities;
 import com.cdancy.bitbucket.rest.domain.admin.UserPage;
+import com.cdancy.bitbucket.rest.domain.common.RequestStatus;
 import com.cdancy.bitbucket.rest.domain.pullrequest.User;
 import org.testng.annotations.Test;
 
@@ -28,20 +29,22 @@ import static org.assertj.core.api.Assertions.assertThat;
 @Test(groups = "live", testName = "AdminApiLiveTest", singleThreaded = true)
 public class AdminApiLiveTest extends BaseBitbucketApiLiveTest {
 
+    private static final String TEST_USER_NAME = "TestUserName";
+
     @Test
     public void testListUsersByGroup() {
         final UserPage userPage = api().listUsersByGroup(defaultBitbucketGroup, null, null, null);
         assertThat(userPage).isNotNull();
         assertThat(userPage.size() > 0).isTrue();
     }
-    
+
     @Test
     public void testListUsersByNonExistentGroup() {
         final UserPage userPage = api().listUsersByGroup(TestUtilities.randomString(), null, null, null);
         assertThat(userPage).isNotNull();
         assertThat(userPage.size() == 0).isTrue();
     }
-    
+
     @Test
     public void testListUsers() {
         final User user = TestUtilities.getDefaultUser(this.bitbucketAuthentication, this.api);
@@ -51,14 +54,36 @@ public class AdminApiLiveTest extends BaseBitbucketApiLiveTest {
             assertThat(userPage.size() > 0).isTrue();
         }
     }
-    
+
     @Test
     public void testListUsersNonExistent() {
         final UserPage userPage = api().listUsers(TestUtilities.randomString(), null, null);
         assertThat(userPage).isNotNull();
         assertThat(userPage.size() == 0).isTrue();
     }
-    
+
+    @Test
+    public void testCreateUser() {
+        final RequestStatus requestStatus = api().createUser(TEST_USER_NAME, TEST_USER_NAME, TEST_USER_NAME,
+                "testUser@test.test", null, null);
+        assertThat(requestStatus).isNotNull();
+        assertThat(requestStatus.value()).isTrue();
+    }
+
+    @Test (dependsOnMethods = "testCreateUser")
+    public void testListSpecificUser() {
+        final UserPage userPage = api().listUsers(TEST_USER_NAME, null, null);
+        assertThat(userPage).isNotNull();
+        assertThat(userPage.size() > 0).isTrue();
+    }
+
+    @Test (dependsOnMethods = "testListSpecificUser")
+    public void testDeleteUser() {
+        final User deletedUser = api().deleteUser(TEST_USER_NAME);
+        assertThat(deletedUser).isNotNull();
+        assertThat(deletedUser.errors().isEmpty()).isTrue();
+    }
+
     private AdminApi api() {
         return api.adminApi();
     }

--- a/src/test/java/com/cdancy/bitbucket/rest/features/AdminApiMockTest.java
+++ b/src/test/java/com/cdancy/bitbucket/rest/features/AdminApiMockTest.java
@@ -39,6 +39,7 @@ public class AdminApiMockTest extends BaseBitbucketMockTest {
     private static final String USERS_POSTFIX = "/admin/users";
     private static final String USER_TEXT = "user";
     private static final String NOTIFY_TEXT = "notify";
+    private static final String DELETE_METHOD = "DELETE";
 
     private final String limitKeyword = "limit";
     private final String startKeyword = "start";
@@ -181,7 +182,7 @@ public class AdminApiMockTest extends BaseBitbucketMockTest {
             assertThat(user.errors()).isEmpty();
 
             final Map<String, ?> queryParams = ImmutableMap.of("name", USER_TEXT);
-            assertSent(server, "DELETE", restApiPath + BitbucketApiMetadata.API_VERSION + USERS_POSTFIX, queryParams);
+            assertSent(server, DELETE_METHOD, restApiPath + BitbucketApiMetadata.API_VERSION + USERS_POSTFIX, queryParams);
         } finally {
             baseApi.close();
             server.shutdown();
@@ -201,7 +202,7 @@ public class AdminApiMockTest extends BaseBitbucketMockTest {
             assertThat(user.errors()).isNotEmpty();
 
             final Map<String, ?> queryParams = ImmutableMap.of("name", USER_TEXT);
-            assertSent(server, "DELETE", restApiPath + BitbucketApiMetadata.API_VERSION + USERS_POSTFIX, queryParams);
+            assertSent(server, DELETE_METHOD, restApiPath + BitbucketApiMetadata.API_VERSION + USERS_POSTFIX, queryParams);
         } finally {
             baseApi.close();
             server.shutdown();

--- a/src/test/java/com/cdancy/bitbucket/rest/features/AdminApiMockTest.java
+++ b/src/test/java/com/cdancy/bitbucket/rest/features/AdminApiMockTest.java
@@ -21,11 +21,14 @@ import com.cdancy.bitbucket.rest.BitbucketApi;
 import com.cdancy.bitbucket.rest.BitbucketApiMetadata;
 import com.cdancy.bitbucket.rest.domain.admin.UserPage;
 import com.cdancy.bitbucket.rest.BaseBitbucketMockTest;
+import com.cdancy.bitbucket.rest.domain.common.RequestStatus;
+import com.cdancy.bitbucket.rest.domain.pullrequest.User;
 import com.google.common.collect.ImmutableMap;
 import com.squareup.okhttp.mockwebserver.MockResponse;
 import com.squareup.okhttp.mockwebserver.MockWebServer;
 import org.testng.annotations.Test;
 
+import java.util.HashMap;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -33,13 +36,17 @@ import static org.assertj.core.api.Assertions.assertThat;
 @Test(groups = "unit", testName = "AdminApiMockTest")
 public class AdminApiMockTest extends BaseBitbucketMockTest {
 
+    private static final String USERS_POSTFIX = "/admin/users";
+    private static final String USER_TEXT = "user";
+    private static final String NOTIFY_TEXT = "notify";
+
     private final String limitKeyword = "limit";
     private final String startKeyword = "start";
     private final String restApiPath = "/rest/api/";
     private final String getMethod = "GET";
 
     private final String localContext = "test";
-            
+
     public void testGetListUserByGroup() throws Exception {
         final MockWebServer server = mockWebServer();
 
@@ -47,7 +54,7 @@ public class AdminApiMockTest extends BaseBitbucketMockTest {
                 .setBody(payloadFromResource("/admin-list-user-by-group.json"))
                 .setResponseCode(200));
         try (final BitbucketApi baseApi = api(server.getUrl("/"))) {
-            
+
             final UserPage up = baseApi.adminApi().listUsersByGroup(localContext, null, 0, 2);
             assertThat(up).isNotNull();
             assertThat(up.errors()).isEmpty();
@@ -69,7 +76,7 @@ public class AdminApiMockTest extends BaseBitbucketMockTest {
                 .setBody(payloadFromResource("/admin-list-user-by-group-error.json"))
                 .setResponseCode(401));
         try (final BitbucketApi baseApi = api(server.getUrl("/"))) {
-            
+
             final UserPage up = baseApi.adminApi().listUsersByGroup(localContext, null, 0, 2);
             assertThat(up).isNotNull();
             assertThat(up.errors()).isNotEmpty();
@@ -81,7 +88,7 @@ public class AdminApiMockTest extends BaseBitbucketMockTest {
             server.shutdown();
         }
     }
-    
+
     public void testListUsers() throws Exception {
         final MockWebServer server = mockWebServer();
 
@@ -97,7 +104,7 @@ public class AdminApiMockTest extends BaseBitbucketMockTest {
 
             final Map<String, ?> queryParams = ImmutableMap.of("filter", "jcitizen", limitKeyword, 2, startKeyword, 0);
             assertSent(server, getMethod, restApiPath + BitbucketApiMetadata.API_VERSION
-                    + "/admin/users", queryParams);
+                    + USERS_POSTFIX, queryParams);
         } finally {
             baseApi.close();
             server.shutdown();
@@ -117,10 +124,98 @@ public class AdminApiMockTest extends BaseBitbucketMockTest {
 
             final Map<String, ?> queryParams = ImmutableMap.of("filter", "blah%20blah", limitKeyword, 2, startKeyword, 0);
             assertSent(server, getMethod, restApiPath + BitbucketApiMetadata.API_VERSION
-                    + "/admin/users", queryParams);
+                    + USERS_POSTFIX, queryParams);
         } finally {
             baseApi.close();
             server.shutdown();
         }
+    }
+
+    public void testCreateUser() throws Exception {
+        final MockWebServer server = mockWebServer();
+
+        server.enqueue(new MockResponse().setResponseCode(204));
+        final BitbucketApi baseApi = api(server.getUrl("/"));
+        final AdminApi api = baseApi.adminApi();
+        try {
+            final RequestStatus status = api.createUser(USER_TEXT, "pass", "display", "email", false, NOTIFY_TEXT);
+            assertThat(status.value()).isTrue();
+            assertThat(status.errors()).isEmpty();
+
+            final Map<String, String> queryParams = createUserQueryParams();
+            assertSent(server, "POST", restApiPath + BitbucketApiMetadata.API_VERSION + USERS_POSTFIX, queryParams);
+        } finally {
+            baseApi.close();
+            server.shutdown();
+        }
+    }
+
+    public void testCreateUserOnError() throws Exception {
+        final MockWebServer server = mockWebServer();
+
+        server.enqueue(new MockResponse().setResponseCode(400));
+        final BitbucketApi baseApi = api(server.getUrl("/"));
+        final AdminApi api = baseApi.adminApi();
+        try {
+            final RequestStatus status = api.createUser(USER_TEXT, "pass", "display", "email", false, NOTIFY_TEXT);
+            assertThat(status.value()).isFalse();
+            assertThat(status.errors()).isNotEmpty();
+
+            final Map<String, String> queryParams = createUserQueryParams();
+            assertSent(server, "POST", restApiPath + BitbucketApiMetadata.API_VERSION + USERS_POSTFIX, queryParams);
+        } finally {
+            baseApi.close();
+            server.shutdown();
+        }
+    }
+
+    public void testDeleteUser() throws Exception {
+        final MockWebServer server = mockWebServer();
+
+        server.enqueue(new MockResponse().setBody(payloadFromResource("/admin-delete-user.json")).setResponseCode(200));
+        final BitbucketApi baseApi = api(server.getUrl("/"));
+        final AdminApi api = baseApi.adminApi();
+        try {
+            final User user = api.deleteUser(USER_TEXT);
+            assertThat(user).isNotNull();
+            assertThat(user.errors()).isEmpty();
+
+            final Map<String, ?> queryParams = ImmutableMap.of("name", USER_TEXT);
+            assertSent(server, "DELETE", restApiPath + BitbucketApiMetadata.API_VERSION + USERS_POSTFIX, queryParams);
+        } finally {
+            baseApi.close();
+            server.shutdown();
+        }
+    }
+
+    public void testDeleteUserOnError() throws Exception {
+        final MockWebServer server = mockWebServer();
+
+        server.enqueue(new MockResponse().setBody(payloadFromResource("/admin-delete-user-error.json")).setResponseCode(400));
+        final BitbucketApi baseApi = api(server.getUrl("/"));
+        final AdminApi api = baseApi.adminApi();
+        try {
+            final User user = api.deleteUser(USER_TEXT);
+            assertThat(user).isNotNull();
+            assertThat(user.name()).isNull();
+            assertThat(user.errors()).isNotEmpty();
+
+            final Map<String, ?> queryParams = ImmutableMap.of("name", USER_TEXT);
+            assertSent(server, "DELETE", restApiPath + BitbucketApiMetadata.API_VERSION + USERS_POSTFIX, queryParams);
+        } finally {
+            baseApi.close();
+            server.shutdown();
+        }
+    }
+
+    private static Map<String, String> createUserQueryParams() {
+        final Map<String, String> queryParams = new HashMap<>();
+        queryParams.put("name", USER_TEXT);
+        queryParams.put("password", "pass");
+        queryParams.put("displayName", "display");
+        queryParams.put("emailAddress", "email");
+        queryParams.put("addToDefaultGroup", "false");
+        queryParams.put(NOTIFY_TEXT, NOTIFY_TEXT);
+        return queryParams;
     }
 }

--- a/src/test/resources/admin-delete-user-error.json
+++ b/src/test/resources/admin-delete-user-error.json
@@ -1,0 +1,14 @@
+{
+  "errors": [
+    {
+      "context": "field_a",
+      "message": "A detailed validation error message for field_a.",
+      "exceptionName": null
+    },
+    {
+      "context": null,
+      "message": "A detailed error message.",
+      "exceptionName": null
+    }
+  ]
+}

--- a/src/test/resources/admin-delete-user.json
+++ b/src/test/resources/admin-delete-user.json
@@ -1,0 +1,14 @@
+{
+  "name": "user",
+  "emailAddress": "email",
+  "id": 101,
+  "displayName": "display",
+  "active": true,
+  "slug": "user",
+  "type": "NORMAL",
+  "directoryName": "Bitbucket Internal Directory",
+  "deletable": true,
+  "lastAuthenticationTimestamp": 1368145580548,
+  "mutableDetails": true,
+  "mutableGroups": true
+}


### PR DESCRIPTION
For issue #144.

It's adding three endpoints - PUT for PR participant (main goal of PR) and two endpoints for admin api (POST and DELETE user) which are needed for participant PUT integ tests.
