### PR TITLE
Fix the delete Tag REST api path

### DIFF
--- a/src/main/java/com/cdancy/bitbucket/rest/features/TagApi.java
+++ b/src/main/java/com/cdancy/bitbucket/rest/features/TagApi.java
@@ -46,14 +46,14 @@ import org.jclouds.rest.annotations.ResponseParser;
 
 @Produces(MediaType.APPLICATION_JSON)
 @RequestFilters(BitbucketAuthenticationFilter.class)
-@Path("/rest/api/{jclouds.api-version}/projects")
+@Path("/rest")
 @SuppressWarnings("PMD.AvoidDuplicateLiterals")
 public interface TagApi {
 
     @Named("tag:create")
     @Documentation({"https://developer.atlassian.com/static/rest/bitbucket-server/latest/bitbucket-rest.html#idm45888278801952"})
     @Consumes(MediaType.APPLICATION_JSON)
-    @Path("/{project}/repos/{repo}/tags")
+    @Path("/api/{jclouds.api-version}/projects/{project}/repos/{repo}/tags")
     @Fallback(BitbucketFallbacks.TagOnError.class)
     @POST
     Tag create(@PathParam("project") String project,
@@ -63,7 +63,7 @@ public interface TagApi {
     @Named("tag:get")
     @Documentation({"https://developer.atlassian.com/static/rest/bitbucket-server/latest/bitbucket-rest.html#idm45888278800832"})
     @Consumes(MediaType.APPLICATION_JSON)
-    @Path("/{project}/repos/{repo}/tags/{tag}")
+    @Path("/api/{jclouds.api-version}/projects/{project}/repos/{repo}/tags/{tag}")
     @Fallback(BitbucketFallbacks.TagOnError.class)
     @GET
     Tag get(@PathParam("project") String project,
@@ -73,7 +73,7 @@ public interface TagApi {
     @Named("tag:list")
     @Documentation({"https://docs.atlassian.com/bitbucket-server/rest/5.7.0/bitbucket-rest.html#idm45568367769888"})
     @Consumes(MediaType.APPLICATION_JSON)
-    @Path("/{project}/repos/{repo}/tags")
+    @Path("/api/{jclouds.api-version}/projects/{project}/repos/{repo}/tags")
     @Fallback(BitbucketFallbacks.TagPageOnError.class)
     @GET
     TagPage list(@PathParam("project") String project,
@@ -86,7 +86,7 @@ public interface TagApi {
     @Named("tag:delete")
     @Documentation({"https://docs.atlassian.com/bitbucket-server/rest/5.4.0/bitbucket-git-rest.html#idm139355817865616"})
     @Consumes(MediaType.APPLICATION_JSON)
-    @Path("/{project}/repos/{repo}/tags/{tag}")
+    @Path("/git/{jclouds.api-version}/projects/{project}/repos/{repo}/tags/{tag}")
     @Fallback(BitbucketFallbacks.RequestStatusOnError.class)
     @ResponseParser(RequestStatusParser.class)
     @DELETE

--- a/src/test/java/com/cdancy/bitbucket/rest/features/TagApiMockTest.java
+++ b/src/test/java/com/cdancy/bitbucket/rest/features/TagApiMockTest.java
@@ -41,6 +41,7 @@ public class TagApiMockTest extends BaseBitbucketMockTest {
     private final String getMethod = "GET";
     private final String deleteMethod = "DELETE";
     private final String restApiPath = "/rest/api/";
+    private final String restGitPath = "/rest/git/";
     private final String reposPath = "/repos/";
     private final String tagsPath = "/tags/";
     private final String projectsPath = "/projects/";
@@ -176,7 +177,7 @@ public class TagApiMockTest extends BaseBitbucketMockTest {
             assertThat(tag.errors().isEmpty()).isTrue();
             assertThat(tag.value()).isTrue();
             
-            assertSent(server, deleteMethod, restApiPath + BitbucketApiMetadata.API_VERSION
+            assertSent(server, deleteMethod, restGitPath + BitbucketApiMetadata.API_VERSION
                     + projectsPath + projectKey + reposPath + repoKey + tagsPath + tagName);
         } finally {
             baseApi.close();
@@ -197,7 +198,7 @@ public class TagApiMockTest extends BaseBitbucketMockTest {
             assertThat(tag).isNotNull();
             assertThat(tag.errors()).isNotEmpty();
             assertThat(tag.value()).isFalse();
-            assertSent(server, deleteMethod, restApiPath + BitbucketApiMetadata.API_VERSION
+            assertSent(server, deleteMethod, restGitPath + BitbucketApiMetadata.API_VERSION
                     + projectsPath + projectKey + reposPath + repoKey + tagsPath + tagName);
         } finally {
             baseApi.close();


### PR DESCRIPTION
This fixes issue #150 

The fix is not elegant, but the underlying implementation by Atlassian is not elegant either. The merit this fix has is that it keeps all the TagApi operations under the same class.

If you have a suggestion on how to do this better, let me know.

CC @cdancy 