### PR TITLE
Adding project permissions #159

### DIFF
--- a/src/main/java/com/cdancy/bitbucket/rest/domain/project/ProjectPermissions.java
+++ b/src/main/java/com/cdancy/bitbucket/rest/domain/project/ProjectPermissions.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.cdancy.bitbucket.rest.domain.project;
+
+import com.cdancy.bitbucket.rest.domain.pullrequest.User;
+import com.cdancy.bitbucket.rest.domain.repository.Group;
+import com.google.auto.value.AutoValue;
+import org.jclouds.javax.annotation.Nullable;
+import org.jclouds.json.SerializedNames;
+
+@AutoValue
+public abstract class ProjectPermissions {
+
+    public enum PermissionsType {
+        PROJECT_ADMIN,
+        PROJECT_WRITE,
+        PROJECT_READ
+    }
+
+    @Nullable
+    public abstract User user();
+
+    @Nullable
+    public abstract Group group();
+
+    public abstract PermissionsType permission();
+
+    @SerializedNames({"user", "group", "permission"})
+    public static ProjectPermissions create(final User user,
+                                            final Group group,
+                                            final PermissionsType type) {
+        return new AutoValue_ProjectPermissions(user, group, type);
+    }
+}

--- a/src/main/java/com/cdancy/bitbucket/rest/domain/project/ProjectPermissionsPage.java
+++ b/src/main/java/com/cdancy/bitbucket/rest/domain/project/ProjectPermissionsPage.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.cdancy.bitbucket.rest.domain.project;
+
+import com.cdancy.bitbucket.rest.BitbucketUtils;
+import com.cdancy.bitbucket.rest.domain.common.Error;
+import com.cdancy.bitbucket.rest.domain.common.ErrorsHolder;
+import com.cdancy.bitbucket.rest.domain.common.Page;
+import com.google.auto.value.AutoValue;
+import org.jclouds.javax.annotation.Nullable;
+import org.jclouds.json.SerializedNames;
+
+import java.util.List;
+
+@AutoValue
+public abstract class ProjectPermissionsPage implements Page<ProjectPermissions>, ErrorsHolder {
+
+    @SerializedNames({ "start", "limit", "size",
+            "nextPageStart", "isLastPage", "values", "errors" })
+    public static ProjectPermissionsPage create(final int start,
+                                                final int limit,
+                                                final int size,
+                                                final int nextPageStart,
+                                                final boolean isLastPage,
+                                                @Nullable final List<ProjectPermissions> values,
+                                                @Nullable final List<Error> errors) {
+
+        return new AutoValue_ProjectPermissionsPage(start,
+                limit,
+                size,
+                nextPageStart,
+                isLastPage,
+                BitbucketUtils.nullToEmpty(values),
+                BitbucketUtils.nullToEmpty(errors));
+    }
+}

--- a/src/main/java/com/cdancy/bitbucket/rest/fallbacks/BitbucketFallbacks.java
+++ b/src/main/java/com/cdancy/bitbucket/rest/fallbacks/BitbucketFallbacks.java
@@ -49,6 +49,7 @@ import com.cdancy.bitbucket.rest.domain.participants.Participants.Status;
 import com.cdancy.bitbucket.rest.domain.participants.ParticipantsPage;
 import com.cdancy.bitbucket.rest.domain.project.Project;
 import com.cdancy.bitbucket.rest.domain.project.ProjectPage;
+import com.cdancy.bitbucket.rest.domain.project.ProjectPermissionsPage;
 import com.cdancy.bitbucket.rest.domain.pullrequest.ChangePage;
 import com.cdancy.bitbucket.rest.domain.pullrequest.CommentPage;
 import com.cdancy.bitbucket.rest.domain.pullrequest.MergeStatus;
@@ -325,6 +326,16 @@ public final class BitbucketFallbacks {
         }
     }
 
+    public static final class ProjectPermissionsPageOnError implements Fallback<Object> {
+        @Override
+        public Object createOrPropagate(final Throwable throwable) throws Exception {
+            if (checkNotNull(throwable, "throwable") != null) {
+                return createProjectPermissionsPageFromErrors(getErrors(throwable.getMessage()));
+            }
+            throw propagate(throwable);
+        }
+    }
+
     public static final class PullRequestSettingsOnError implements Fallback<Object> {
         @Override
         public Object createOrPropagate(final Throwable throwable) throws Exception {
@@ -569,6 +580,10 @@ public final class BitbucketFallbacks {
 
     public static Project createProjectFromErrors(final List<Error> errors) {
         return Project.create(null, -1, null, null, false, null, null, errors);
+    }
+
+    public static ProjectPermissionsPage createProjectPermissionsPageFromErrors(final List<Error> errors) {
+        return ProjectPermissionsPage.create(-1, -1, -1, -1, true, null, errors);
     }
 
     public static PullRequestSettings createPullRequestSettingsFromErrors(final List<Error> errors) {

--- a/src/main/java/com/cdancy/bitbucket/rest/features/ProjectApi.java
+++ b/src/main/java/com/cdancy/bitbucket/rest/features/ProjectApi.java
@@ -24,12 +24,14 @@ import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
+import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 
+import com.cdancy.bitbucket.rest.domain.project.ProjectPermissionsPage;
 import org.jclouds.javax.annotation.Nullable;
 import org.jclouds.rest.annotations.BinderParam;
 import org.jclouds.rest.annotations.Fallback;
@@ -83,4 +85,66 @@ public interface ProjectApi {
                      @Nullable @QueryParam("permission") String permission,
                      @Nullable @QueryParam("start") Integer start,
                      @Nullable @QueryParam("limit") Integer limit);
+
+    @Named("project:create-permissions-by-user")
+    @Documentation({"https://developer.atlassian.com/static/rest/bitbucket-server/5.0.0/bitbucket-rest.html#idm45659054938032"})
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Path("/{project}/permissions/users")
+    @Fallback(BitbucketFallbacks.RequestStatusOnError.class)
+    @ResponseParser(RequestStatusParser.class)
+    @PUT
+    RequestStatus createPermissionsByUser(@PathParam("project") String project,
+                                          @QueryParam("permission") String permission,
+                                          @QueryParam("name") String name);
+
+    @Named("project:delete-permissions-by-user")
+    @Documentation({"https://developer.atlassian.com/static/rest/bitbucket-server/5.0.0/bitbucket-rest.html#idm45659054938032"})
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Path("/{project}/permissions/users")
+    @Fallback(BitbucketFallbacks.RequestStatusOnError.class)
+    @ResponseParser(RequestStatusParser.class)
+    @DELETE
+    RequestStatus deletePermissionsByUser(@PathParam("project") String project,
+                                          @QueryParam("name") String name);
+
+    @Named("project:list-permissions-by-user")
+    @Documentation({"https://developer.atlassian.com/static/rest/bitbucket-server/5.0.0/bitbucket-rest.html#idm45659054938032"})
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Path("/{project}/permissions/users")
+    @Fallback(BitbucketFallbacks.ProjectPermissionsPageOnError.class)
+    @GET
+    ProjectPermissionsPage listPermissionsByUser(@PathParam("project") String project,
+                                                 @Nullable @QueryParam("start") Integer start,
+                                                 @Nullable @QueryParam("limit") Integer limit);
+
+    @Named("project:create-permissions-by-group")
+    @Documentation({"https://developer.atlassian.com/static/rest/bitbucket-server/5.0.0/bitbucket-rest.html#idm45659054969200"})
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Path("/{project}/permissions/groups")
+    @Fallback(BitbucketFallbacks.RequestStatusOnError.class)
+    @ResponseParser(RequestStatusParser.class)
+    @PUT
+    RequestStatus createPermissionsByGroup(@PathParam("project") String project,
+                                           @QueryParam("permission") String permission,
+                                           @QueryParam("name") String name);
+
+    @Named("project:delete-permissions-by-group")
+    @Documentation({"https://developer.atlassian.com/static/rest/bitbucket-server/5.0.0/bitbucket-rest.html#idm45659054969200"})
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Path("/{project}/permissions/groups")
+    @Fallback(BitbucketFallbacks.RequestStatusOnError.class)
+    @ResponseParser(RequestStatusParser.class)
+    @DELETE
+    RequestStatus deletePermissionsByGroup(@PathParam("project") String project,
+                                           @QueryParam("name") String name);
+
+    @Named("project:list-permissions-by-group")
+    @Documentation({"https://developer.atlassian.com/static/rest/bitbucket-server/5.0.0/bitbucket-rest.html#idm45659054969200"})
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Path("/{project}/permissions/groups")
+    @Fallback(BitbucketFallbacks.ProjectPermissionsPageOnError.class)
+    @GET
+    ProjectPermissionsPage listPermissionsByGroup(@PathParam("project") String project,
+                                                  @Nullable @QueryParam("start") Integer start,
+                                                  @Nullable @QueryParam("limit") Integer limit);
 }

--- a/src/test/java/com/cdancy/bitbucket/rest/features/ProjectApiMockTest.java
+++ b/src/test/java/com/cdancy/bitbucket/rest/features/ProjectApiMockTest.java
@@ -21,6 +21,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Map;
 
+import com.cdancy.bitbucket.rest.domain.project.ProjectPermissionsPage;
 import org.testng.annotations.Test;
 
 import com.cdancy.bitbucket.rest.BitbucketApi;
@@ -42,7 +43,25 @@ public class ProjectApiMockTest extends BaseBitbucketMockTest {
 
     private final String localMethod = "GET";
     private final String localPath = "/projects";
-    
+
+    private final String projectKey = "PRJ";
+    private final String getMethod = "GET";
+    private final String deleteMethod = "DELETE";
+    private final String putMethod = "PUT";
+
+    private final String restApiPath = "/rest/api/";
+    private final String projectsPath = "/projects/";
+    private final String permissionsPath = "/permissions/";
+    private final String usersPath = permissionsPath + "users";
+    private final String groupsPath = permissionsPath + "groups";
+
+    private final String limitKeyword = "limit";
+    private final String startKeyword = "start";
+    private final String nameKeyword = "name";
+    private final String permissionKeyword = "permission";
+    private final String oneTwoThreeKeyword = "123";
+    private final String testOneTwoThreeKeyword = "test" + oneTwoThreeKeyword;
+
     public void testCreateProject() throws Exception {
         final MockWebServer server = mockWebServer();
 
@@ -50,11 +69,11 @@ public class ProjectApiMockTest extends BaseBitbucketMockTest {
                 .setBody(payloadFromResource("/project.json"))
                 .setResponseCode(201));
         try (final BitbucketApi baseApi = api(server.getUrl("/"))) {
-            
+
             final String projectKey = "HELLO";
             final CreateProject createProject = CreateProject.create(projectKey, null, null, null);
             final Project project = baseApi.projectApi().create(createProject);
-            
+
             assertThat(project).isNotNull();
             assertThat(project.errors()).isEmpty();
             assertThat(project.key()).isEqualToIgnoringCase(projectKey);
@@ -73,11 +92,11 @@ public class ProjectApiMockTest extends BaseBitbucketMockTest {
                 .setBody(payloadFromResource("/project-create-fail.json"))
                 .setResponseCode(400));
         try (final BitbucketApi baseApi = api(server.getUrl("/"))) {
-            
+
             final String projectKey = "9999";
             final CreateProject createProject = CreateProject.create(projectKey, null, null, null);
             final Project project = baseApi.projectApi().create(createProject);
-            
+
             assertThat(project).isNotNull();
             assertThat(project.errors()).isNotEmpty();
             assertSent(server, "POST", restBasePath + BitbucketApiMetadata.API_VERSION + localPath);
@@ -93,10 +112,10 @@ public class ProjectApiMockTest extends BaseBitbucketMockTest {
                 .setBody(payloadFromResource("/project.json"))
                 .setResponseCode(200));
         try (final BitbucketApi baseApi = api(server.getUrl("/"))) {
-            
+
             final String projectKey = "HELLO";
             final Project project = baseApi.projectApi().get(projectKey);
-            
+
             assertThat(project).isNotNull();
             assertThat(project.errors()).isEmpty();
             assertThat(project.key()).isEqualToIgnoringCase(projectKey);
@@ -114,10 +133,10 @@ public class ProjectApiMockTest extends BaseBitbucketMockTest {
                 .setBody(payloadFromResource("/project-not-exist.json"))
                 .setResponseCode(404));
         try (final BitbucketApi baseApi = api(server.getUrl("/"))) {
-            
+
             final String projectKey = "HelloWorld";
             final Project project = baseApi.projectApi().get(projectKey);
-            
+
             assertThat(project).isNotNull();
             assertThat(project.errors()).isNotEmpty();
             assertSent(server, localMethod, restBasePath + BitbucketApiMetadata.API_VERSION + localPath + "/" + projectKey);
@@ -131,7 +150,7 @@ public class ProjectApiMockTest extends BaseBitbucketMockTest {
 
         server.enqueue(new MockResponse().setResponseCode(204));
         try (final BitbucketApi baseApi = api(server.getUrl("/"))) {
-            
+
             final String projectKey = "HELLO";
             final RequestStatus success = baseApi.projectApi().delete(projectKey);
             assertThat(success).isNotNull();
@@ -150,7 +169,7 @@ public class ProjectApiMockTest extends BaseBitbucketMockTest {
                 .setBody(payloadFromResource("/project-not-exist.json"))
                 .setResponseCode(404));
         try (final BitbucketApi baseApi = api(server.getUrl("/"))) {
-            
+
             final String projectKey = "NOTEXIST";
             final RequestStatus success = baseApi.projectApi().delete(projectKey);
             assertThat(success).isNotNull();
@@ -174,7 +193,7 @@ public class ProjectApiMockTest extends BaseBitbucketMockTest {
 
             assertThat(projectPage).isNotNull();
             assertThat(projectPage.errors()).isEmpty();
-            
+
             assertThat(projectPage.size()).isLessThanOrEqualTo(projectPage.limit());
             assertThat(projectPage.start()).isEqualTo(0);
             assertThat(projectPage.isLastPage()).isTrue();
@@ -212,14 +231,14 @@ public class ProjectApiMockTest extends BaseBitbucketMockTest {
 
             assertThat(projectPage.values()).hasSize(size);
             assertThat(projectPage.values()).hasOnlyElementsOfType(Project.class);
-            
+
             final Map<String, ?> queryParams = ImmutableMap.of("start", start, "limit", limit);
             assertSent(server, localMethod, restBasePath + BitbucketApiMetadata.API_VERSION + localPath, queryParams);
         } finally {
             server.shutdown();
         }
     }
-    
+
     public void testGetProjectListNonExistent() throws Exception {
         final MockWebServer server = mockWebServer();
 
@@ -234,6 +253,266 @@ public class ProjectApiMockTest extends BaseBitbucketMockTest {
             assertThat(projectPage.errors()).isNotEmpty();
             assertSent(server, localMethod, restBasePath + BitbucketApiMetadata.API_VERSION + localPath);
         } finally {
+            server.shutdown();
+        }
+    }
+
+    public void testCreatePermissionByUser() throws Exception {
+        final MockWebServer server = mockWebServer();
+
+        server.enqueue(new MockResponse().setResponseCode(204));
+        final BitbucketApi baseApi = api(server.getUrl("/"));
+        final ProjectApi api = baseApi.projectApi();
+        try {
+
+            final RequestStatus success = api.createPermissionsByUser(projectKey, testOneTwoThreeKeyword, oneTwoThreeKeyword);
+            assertThat(success).isNotNull();
+            assertThat(success.value()).isTrue();
+            assertThat(success.errors()).isEmpty();
+            final Map<String, ?> queryParams = ImmutableMap.of(nameKeyword, oneTwoThreeKeyword, permissionKeyword, testOneTwoThreeKeyword);
+            assertSent(server, putMethod, restApiPath + BitbucketApiMetadata.API_VERSION
+                    + projectsPath + projectKey + usersPath, queryParams);
+        } finally {
+            baseApi.close();
+            server.shutdown();
+        }
+    }
+
+    public void testListPermissionByUser() throws Exception {
+        final MockWebServer server = mockWebServer();
+
+        server.enqueue(new MockResponse().setBody(payloadFromResource("/project-permission-users.json")).setResponseCode(200));
+        final BitbucketApi baseApi = api(server.getUrl("/"));
+        final ProjectApi api = baseApi.projectApi();
+        try {
+
+            final ProjectPermissionsPage projectPermissionsPage = api.listPermissionsByUser(projectKey, 0, 100);
+            assertThat(projectPermissionsPage).isNotNull();
+            assertThat(projectPermissionsPage.errors()).isEmpty();
+            assertThat(projectPermissionsPage.size() == 1).isTrue();
+            assertThat(projectPermissionsPage.values().get(0).group() == null).isTrue();
+            assertThat(projectPermissionsPage.values().get(0).user().name().equals("test")).isTrue();
+
+            final Map<String, ?> queryParams = ImmutableMap.of(limitKeyword, 100, startKeyword, 0);
+            assertSent(server, getMethod, restApiPath + BitbucketApiMetadata.API_VERSION
+                        + projectsPath + projectKey + usersPath, queryParams);
+        } finally {
+            baseApi.close();
+            server.shutdown();
+        }
+    }
+
+    public void testCreatePermissionByGroup() throws Exception {
+        final MockWebServer server = mockWebServer();
+
+        server.enqueue(new MockResponse().setResponseCode(204));
+        final BitbucketApi baseApi = api(server.getUrl("/"));
+        final ProjectApi api = baseApi.projectApi();
+        try {
+
+            final RequestStatus success = api.createPermissionsByGroup(projectKey, testOneTwoThreeKeyword, oneTwoThreeKeyword);
+            assertThat(success).isNotNull();
+            assertThat(success.value()).isTrue();
+            assertThat(success.errors()).isEmpty();
+            final Map<String, ?> queryParams = ImmutableMap.of(nameKeyword, oneTwoThreeKeyword, permissionKeyword, testOneTwoThreeKeyword);
+            assertSent(server, putMethod, restApiPath + BitbucketApiMetadata.API_VERSION
+                    + projectsPath + projectKey + groupsPath, queryParams);
+        } finally {
+            baseApi.close();
+            server.shutdown();
+        }
+    }
+
+    public void testListPermissionByGroup() throws Exception {
+        final MockWebServer server = mockWebServer();
+
+        server.enqueue(new MockResponse().setBody(payloadFromResource("/project-permission-group.json")).setResponseCode(200));
+        final BitbucketApi baseApi = api(server.getUrl("/"));
+        final ProjectApi api = baseApi.projectApi();
+        try {
+
+            final ProjectPermissionsPage projectPermissionsPage = api.listPermissionsByGroup(projectKey, 0, 100);
+            assertThat(projectPermissionsPage).isNotNull();
+            assertThat(projectPermissionsPage.errors()).isEmpty();
+            assertThat(projectPermissionsPage.size() == 1).isTrue();
+            assertThat(projectPermissionsPage.values().get(0).user() == null).isTrue();
+            assertThat(projectPermissionsPage.values().get(0).group().name().equals("test12345")).isTrue();
+
+            final Map<String, ?> queryParams = ImmutableMap.of(limitKeyword, 100, startKeyword, 0);
+            assertSent(server, getMethod, restApiPath + BitbucketApiMetadata.API_VERSION
+                    + projectsPath + projectKey + groupsPath, queryParams);
+        } finally {
+            baseApi.close();
+            server.shutdown();
+        }
+    }
+
+    public void testCreatePermissionByUserOnError() throws Exception {
+        final MockWebServer server = mockWebServer();
+
+        server.enqueue(new MockResponse().setResponseCode(404));
+        final BitbucketApi baseApi = api(server.getUrl("/"));
+        final ProjectApi api = baseApi.projectApi();
+        try {
+
+            final RequestStatus success = api.createPermissionsByUser(projectKey, testOneTwoThreeKeyword, oneTwoThreeKeyword);
+            assertThat(success).isNotNull();
+            assertThat(success.value()).isFalse();
+            assertThat(success.errors()).isNotEmpty();
+            final Map<String, ?> queryParams = ImmutableMap.of(nameKeyword, oneTwoThreeKeyword, permissionKeyword, testOneTwoThreeKeyword);
+            assertSent(server, putMethod, restApiPath + BitbucketApiMetadata.API_VERSION
+                    + projectsPath + projectKey + usersPath, queryParams);
+        } finally {
+            baseApi.close();
+            server.shutdown();
+        }
+    }
+
+    public void testListPermissionByUserOnError() throws Exception {
+        final MockWebServer server = mockWebServer();
+
+        server.enqueue(new MockResponse().setBody(payloadFromResource("/project-permission-users-error.json")).setResponseCode(404));
+        final BitbucketApi baseApi = api(server.getUrl("/"));
+        final ProjectApi api = baseApi.projectApi();
+        try {
+
+            final ProjectPermissionsPage projectPermissionsPage = api.listPermissionsByUser(projectKey, 0, 100);
+            assertThat(projectPermissionsPage).isNotNull();
+            assertThat(projectPermissionsPage.values()).isEmpty();
+            assertThat(projectPermissionsPage.errors()).isNotEmpty();
+
+            final Map<String, ?> queryParams = ImmutableMap.of(limitKeyword, 100, startKeyword, 0);
+            assertSent(server, getMethod, restApiPath + BitbucketApiMetadata.API_VERSION
+                    + projectsPath + projectKey + usersPath, queryParams);
+        } finally {
+            baseApi.close();
+            server.shutdown();
+        }
+    }
+
+    public void testCreatePermissionByGroupOnError() throws Exception {
+        final MockWebServer server = mockWebServer();
+
+        server.enqueue(new MockResponse().setResponseCode(404));
+        final BitbucketApi baseApi = api(server.getUrl("/"));
+        final ProjectApi api = baseApi.projectApi();
+        try {
+
+            final RequestStatus success = api.createPermissionsByGroup(projectKey, testOneTwoThreeKeyword, oneTwoThreeKeyword);
+            assertThat(success).isNotNull();
+            assertThat(success.value()).isFalse();
+            assertThat(success.errors()).isNotEmpty();
+            final Map<String, ?> queryParams = ImmutableMap.of(nameKeyword, oneTwoThreeKeyword, permissionKeyword, testOneTwoThreeKeyword);
+            assertSent(server, putMethod, restApiPath + BitbucketApiMetadata.API_VERSION
+                    + projectsPath + projectKey + groupsPath, queryParams);
+        } finally {
+            baseApi.close();
+            server.shutdown();
+        }
+    }
+
+    public void testDeletePermissionByUser() throws Exception {
+        final MockWebServer server = mockWebServer();
+
+        server.enqueue(new MockResponse().setResponseCode(204));
+        final BitbucketApi baseApi = api(server.getUrl("/"));
+        final ProjectApi api = baseApi.projectApi();
+        try {
+
+            final RequestStatus success = api.deletePermissionsByUser(projectKey, testOneTwoThreeKeyword);
+            assertThat(success).isNotNull();
+            assertThat(success.value()).isTrue();
+            assertThat(success.errors()).isEmpty();
+            final Map<String, ?> queryParams = ImmutableMap.of(nameKeyword, testOneTwoThreeKeyword);
+            assertSent(server, deleteMethod, restApiPath + BitbucketApiMetadata.API_VERSION
+                    + projectsPath + projectKey + usersPath, queryParams);
+        } finally {
+            baseApi.close();
+            server.shutdown();
+        }
+    }
+
+    public void testDeletePermissionByGroup() throws Exception {
+        final MockWebServer server = mockWebServer();
+
+        server.enqueue(new MockResponse().setResponseCode(204));
+        final BitbucketApi baseApi = api(server.getUrl("/"));
+        final ProjectApi api = baseApi.projectApi();
+        try {
+
+            final RequestStatus success = api.deletePermissionsByGroup(projectKey, testOneTwoThreeKeyword);
+            assertThat(success).isNotNull();
+            assertThat(success.value()).isTrue();
+            assertThat(success.errors()).isEmpty();
+            final Map<String, ?> queryParams = ImmutableMap.of(nameKeyword, testOneTwoThreeKeyword);
+            assertSent(server, deleteMethod, restApiPath + BitbucketApiMetadata.API_VERSION
+                    + projectsPath + projectKey + groupsPath, queryParams);
+        } finally {
+            baseApi.close();
+            server.shutdown();
+        }
+    }
+
+    public void testDeletePermissionByUserOnError() throws Exception {
+        final MockWebServer server = mockWebServer();
+
+        server.enqueue(new MockResponse().setResponseCode(404));
+        final BitbucketApi baseApi = api(server.getUrl("/"));
+        final ProjectApi api = baseApi.projectApi();
+        try {
+
+            final RequestStatus success = api.deletePermissionsByUser(projectKey, testOneTwoThreeKeyword);
+            assertThat(success).isNotNull();
+            assertThat(success.value()).isFalse();
+            assertThat(success.errors()).isNotEmpty();
+            final Map<String, ?> queryParams = ImmutableMap.of(nameKeyword, testOneTwoThreeKeyword);
+            assertSent(server, deleteMethod, restApiPath + BitbucketApiMetadata.API_VERSION
+                    + projectsPath + projectKey + usersPath, queryParams);
+        } finally {
+            baseApi.close();
+            server.shutdown();
+        }
+    }
+
+    public void testDeletePermissionByGroupOnError() throws Exception {
+        final MockWebServer server = mockWebServer();
+
+        server.enqueue(new MockResponse().setResponseCode(404));
+        final BitbucketApi baseApi = api(server.getUrl("/"));
+        final ProjectApi api = baseApi.projectApi();
+        try {
+
+            final RequestStatus success = api.deletePermissionsByGroup(projectKey, testOneTwoThreeKeyword);
+            assertThat(success).isNotNull();
+            assertThat(success.value()).isFalse();
+            assertThat(success.errors()).isNotEmpty();
+            final Map<String, ?> queryParams = ImmutableMap.of(nameKeyword, testOneTwoThreeKeyword);
+            assertSent(server, deleteMethod, restApiPath + BitbucketApiMetadata.API_VERSION
+                    + projectsPath + projectKey + groupsPath, queryParams);
+        } finally {
+            baseApi.close();
+            server.shutdown();
+        }
+    }
+
+    public void testListPermissionByGroupOnError() throws Exception {
+        final MockWebServer server = mockWebServer();
+
+        server.enqueue(new MockResponse().setBody(payloadFromResource("/project-permission-group-error.json")).setResponseCode(404));
+        final BitbucketApi baseApi = api(server.getUrl("/"));
+        final ProjectApi api = baseApi.projectApi();
+        try {
+
+            final ProjectPermissionsPage projectPermissionsPage = api.listPermissionsByGroup(projectKey, 0, 100);
+            assertThat(projectPermissionsPage).isNotNull();
+            assertThat(projectPermissionsPage.values()).isEmpty();
+            assertThat(projectPermissionsPage.errors()).isNotEmpty();
+
+            final Map<String, ?> queryParams = ImmutableMap.of(limitKeyword, 100, startKeyword, 0);
+            assertSent(server, getMethod, restApiPath + BitbucketApiMetadata.API_VERSION
+                    + projectsPath + projectKey + groupsPath, queryParams);
+        } finally {
+            baseApi.close();
             server.shutdown();
         }
     }

--- a/src/test/resources/project-permission-group-error.json
+++ b/src/test/resources/project-permission-group-error.json
@@ -1,0 +1,9 @@
+{
+  "errors": [
+    {
+      "context": null,
+      "exceptionName": "com.atlassian.bitbucket.project.NoSuchProjectException",
+      "message": "Project test123 does not exist."
+    }
+  ]
+}

--- a/src/test/resources/project-permission-group.json
+++ b/src/test/resources/project-permission-group.json
@@ -1,0 +1,14 @@
+{
+  "isLastPage": true,
+  "limit": 25,
+  "size": 1,
+  "start": 0,
+  "values": [
+    {
+      "group": {
+        "name": "test12345"
+      },
+      "permission": "PROJECT_WRITE"
+    }
+  ]
+}

--- a/src/test/resources/project-permission-users-error.json
+++ b/src/test/resources/project-permission-users-error.json
@@ -1,0 +1,9 @@
+{
+  "errors": [
+    {
+      "context": null,
+      "exceptionName": "com.atlassian.bitbucket.project.NoSuchProjectException",
+      "message": "Project test123 does not exist."
+    }
+  ]
+}

--- a/src/test/resources/project-permission-users.json
+++ b/src/test/resources/project-permission-users.json
@@ -1,0 +1,26 @@
+{
+  "isLastPage": true,
+  "limit": 25,
+  "size": 1,
+  "start": 0,
+  "values": [
+    {
+      "permission": "PROJECT_READ",
+      "user": {
+        "active": true,
+        "displayName": "test123 123",
+        "emailAddress": "test@amce.com",
+        "id": 339,
+        "links": {
+          "self": [
+            {
+              "href": "https://bitbucket.amce.com/users/test"
+            }
+          ]
+        },
+        "name": "test",
+        "type": "NORMAL"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Adding project level permissions API (#159) which is very similar to repository level permissions (most of the code reused and tests added too).
