### PR TITLE
If a task contains both a comment and a like then parsing would fail.

### DIFF
--- a/src/main/java/com/cdancy/bitbucket/rest/domain/comment/TaskAnchor.java
+++ b/src/main/java/com/cdancy/bitbucket/rest/domain/comment/TaskAnchor.java
@@ -21,13 +21,15 @@ import com.cdancy.bitbucket.rest.domain.pullrequest.Author;
 import com.cdancy.bitbucket.rest.BitbucketUtils;
 import com.google.auto.value.AutoValue;
 import java.util.Map;
+
+import com.google.gson.JsonElement;
 import org.jclouds.javax.annotation.Nullable;
 import org.jclouds.json.SerializedNames;
 
 @AutoValue
 public abstract class TaskAnchor {
 
-    public abstract Map<String, String> properties();
+    public abstract Map<String, JsonElement> properties();
 
     public abstract int id();
 
@@ -53,7 +55,7 @@ public abstract class TaskAnchor {
 
     @SerializedNames({ "properties", "id", "version", "text", 
             "author", "createdDate", "updatedDate", "permittedOperations", "type" })
-    public static TaskAnchor create(final Map<String, String> properties, 
+    public static TaskAnchor create(final Map<String, JsonElement> properties,
             final int id, 
             final int version, 
             final String text, 

--- a/src/test/java/com/cdancy/bitbucket/rest/features/PullRequestApiMockTest.java
+++ b/src/test/java/com/cdancy/bitbucket/rest/features/PullRequestApiMockTest.java
@@ -477,6 +477,8 @@ public class PullRequestApiMockTest extends BaseBitbucketMockTest {
             final Task task = comments.tasks().get(0);
             assertThat(task.anchor().type()).isEqualTo("COMMENT");
             assertThat(task.state()).isEqualTo("OPEN");
+            assertThat(task.anchor().properties().keySet().contains("likedBy"));
+            assertThat(task.anchor().properties().keySet().contains("repositoryId"));
 
             final Map<String, ?> queryParams = ImmutableMap.of(startKeyword, "0", limitKeyword, 5);
             assertSent(server, getMethod, restApiPath + BitbucketApiMetadata.API_VERSION

--- a/src/test/resources/pull-request-activities.json
+++ b/src/test/resources/pull-request-activities.json
@@ -68,7 +68,7 @@
          "action":"COMMENTED",
          "commentAction":"ADDED",
          "comment":{  
-            "properties":{  
+            "properties":{
                "repositoryId":59
             },
             "id":1465,
@@ -98,7 +98,28 @@
             "tasks":[  
                {  
                   "anchor":{  
-                     "properties":{  
+                     "properties":{
+                        "likedBy": {
+                           "total": 1,
+                           "likers": [
+                              {
+                                 "name": "example_user",
+                                 "emailAddress": "user@example.com",
+                                 "id": 1,
+                                 "displayName": "Example User",
+                                 "active": true,
+                                 "slug": "example_user",
+                                 "type": "NORMAL",
+                                 "links": {
+                                    "self": [
+                                       {
+                                          "href": "http://git.public.io/users/example_user"
+                                       }
+                                    ]
+                                 }
+                              }
+                           ]
+                        },
                         "repositoryId":59
                      },
                      "id":1465,


### PR DESCRIPTION
The presence of a like was unexpected and would lead to a parsing failure:

```
    ERROR [2019-01-15 00:21:03,721] org.jclouds.http.functions.ParseJson: Error parsing input: java.lang.IllegalStateException: Expected a string but was BEGIN_OBJECT at line 141 column 29 path $.values[4].comment.tasks[0].anchor.properties.
    ! java.lang.IllegalStateException: Expected a string but was BEGIN_OBJECT at line 141 column 29 path $.values[4].comment.tasks[0].anchor.properties.
    ! at com.google.gson.stream.JsonReader.nextString(JsonReader.java:838)
    ! at com.google.gson.internal.bind.TypeAdapters$16.read(TypeAdapters.java:422)
// rest of stack omitted
```

Using [this diff](https://github.com/cdancy/bitbucket-rest/pull/106/files) as inspiration I have come up with a fix that can be used as is or as a base for something else.

`closes #167 `
