### PR TITLE
Issue-179 Implement last-modified API

### DIFF
--- a/src/main/java/com/cdancy/bitbucket/rest/domain/file/LastModified.java
+++ b/src/main/java/com/cdancy/bitbucket/rest/domain/file/LastModified.java
@@ -29,7 +29,7 @@ import java.util.List;
 import java.util.Map;
 
 @AutoValue
-public abstract class LastModifiedSummary implements ErrorsHolder {
+public abstract class LastModified implements ErrorsHolder {
 
     @Nullable
     public abstract Map<String, Commit> files();
@@ -37,15 +37,15 @@ public abstract class LastModifiedSummary implements ErrorsHolder {
     @Nullable
     public abstract Commit latestCommit();
 
-    LastModifiedSummary() {
+    LastModified() {
     }
 
     @SerializedNames({ "files", "latestCommit", "errors" })
-    public static LastModifiedSummary create(final Map<String, Commit> files,
-                 final Commit latestCommit,
-                 final List<Error> errors) {
-        return new AutoValue_LastModifiedSummary(BitbucketUtils.nullToEmpty(errors),
-            files,
+    public static LastModified create(final Map<String, Commit> files,
+            final Commit latestCommit,
+            final List<Error> errors) {
+        return new AutoValue_LastModified(BitbucketUtils.nullToEmpty(errors),
+            BitbucketUtils.nullToEmpty(files),
             latestCommit);
     }
 

--- a/src/main/java/com/cdancy/bitbucket/rest/domain/file/LastModifiedSummary.java
+++ b/src/main/java/com/cdancy/bitbucket/rest/domain/file/LastModifiedSummary.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.cdancy.bitbucket.rest.domain.file;
+
+import com.cdancy.bitbucket.rest.BitbucketUtils;
+import com.cdancy.bitbucket.rest.domain.commit.Commit;
+import com.cdancy.bitbucket.rest.domain.common.Error;
+import com.cdancy.bitbucket.rest.domain.common.ErrorsHolder;
+import com.google.auto.value.AutoValue;
+import org.jclouds.javax.annotation.Nullable;
+import org.jclouds.json.SerializedNames;
+
+import java.util.List;
+import java.util.Map;
+
+@AutoValue
+public abstract class LastModifiedSummary implements ErrorsHolder {
+
+    @Nullable
+    public abstract Map<String, Commit> files();
+
+    @Nullable
+    public abstract Commit latestCommit();
+
+    LastModifiedSummary() {
+    }
+
+    @SerializedNames({ "files", "latestCommit", "errors" })
+    public static LastModifiedSummary create(final Map<String, Commit> files,
+                 final Commit latestCommit,
+                 final List<Error> errors) {
+        return new AutoValue_LastModifiedSummary(BitbucketUtils.nullToEmpty(errors),
+            files,
+            latestCommit);
+    }
+
+}

--- a/src/main/java/com/cdancy/bitbucket/rest/fallbacks/BitbucketFallbacks.java
+++ b/src/main/java/com/cdancy/bitbucket/rest/fallbacks/BitbucketFallbacks.java
@@ -41,7 +41,7 @@ import com.cdancy.bitbucket.rest.domain.common.RequestStatus;
 import com.cdancy.bitbucket.rest.domain.common.Veto;
 import com.cdancy.bitbucket.rest.domain.defaultreviewers.Condition;
 import com.cdancy.bitbucket.rest.domain.file.FilesPage;
-import com.cdancy.bitbucket.rest.domain.file.LastModifiedSummary;
+import com.cdancy.bitbucket.rest.domain.file.LastModified;
 import com.cdancy.bitbucket.rest.domain.file.LinePage;
 import com.cdancy.bitbucket.rest.domain.file.RawContent;
 import com.cdancy.bitbucket.rest.domain.participants.Participants;
@@ -548,8 +548,8 @@ public final class BitbucketFallbacks {
         return FilesPage.create(-1, -1, -1, -1, true, null, errors);
     }
 
-    public static LastModifiedSummary createLastModifiedSummaryFromErrors(final List<Error> errors) {
-        return LastModifiedSummary.create(null, null, errors);
+    public static LastModified createLastModifiedSummaryFromErrors(final List<Error> errors) {
+        return LastModified.create(null, null, errors);
     }
 
     public static Branch createBranchFromErrors(final List<Error> errors) {

--- a/src/main/java/com/cdancy/bitbucket/rest/fallbacks/BitbucketFallbacks.java
+++ b/src/main/java/com/cdancy/bitbucket/rest/fallbacks/BitbucketFallbacks.java
@@ -41,6 +41,7 @@ import com.cdancy.bitbucket.rest.domain.common.RequestStatus;
 import com.cdancy.bitbucket.rest.domain.common.Veto;
 import com.cdancy.bitbucket.rest.domain.defaultreviewers.Condition;
 import com.cdancy.bitbucket.rest.domain.file.FilesPage;
+import com.cdancy.bitbucket.rest.domain.file.LastModifiedSummary;
 import com.cdancy.bitbucket.rest.domain.file.LinePage;
 import com.cdancy.bitbucket.rest.domain.file.RawContent;
 import com.cdancy.bitbucket.rest.domain.participants.Participants;
@@ -473,6 +474,15 @@ public final class BitbucketFallbacks {
         }
     }
 
+    public static final class LastModifiedSummaryOnError implements Fallback<Object> {
+        public Object createOrPropagate(final Throwable throwable) throws Exception {
+            if (checkNotNull(throwable, "throwable") != null) {
+                return createLastModifiedSummaryFromErrors(getErrors(throwable.getMessage()));
+            }
+            throw propagate(throwable);
+        }
+    }
+
     public static final class RawContentOnError implements Fallback<Object> {
         @Override
         public Object createOrPropagate(final Throwable throwable) throws Exception {
@@ -536,6 +546,10 @@ public final class BitbucketFallbacks {
 
     public static FilesPage createFilesPageFromErrors(final List<Error> errors) {
         return FilesPage.create(-1, -1, -1, -1, true, null, errors);
+    }
+
+    public static LastModifiedSummary createLastModifiedSummaryFromErrors(final List<Error> errors) {
+        return LastModifiedSummary.create(null, null, errors);
     }
 
     public static Branch createBranchFromErrors(final List<Error> errors) {

--- a/src/main/java/com/cdancy/bitbucket/rest/features/FileApi.java
+++ b/src/main/java/com/cdancy/bitbucket/rest/features/FileApi.java
@@ -20,7 +20,7 @@ package com.cdancy.bitbucket.rest.features;
 import com.cdancy.bitbucket.rest.annotations.Documentation;
 import com.cdancy.bitbucket.rest.domain.commit.Commit;
 import com.cdancy.bitbucket.rest.domain.file.FilesPage;
-import com.cdancy.bitbucket.rest.domain.file.LastModifiedSummary;
+import com.cdancy.bitbucket.rest.domain.file.LastModified;
 import com.cdancy.bitbucket.rest.domain.file.LinePage;
 import com.cdancy.bitbucket.rest.domain.file.RawContent;
 import com.cdancy.bitbucket.rest.fallbacks.BitbucketFallbacks;
@@ -112,7 +112,7 @@ public interface FileApi {
     @Path("/rest/api/{jclouds.api-version}/projects/{project}/repos/{repo}/last-modified")
     @Fallback(BitbucketFallbacks.LastModifiedSummaryOnError.class)
     @GET
-    LastModifiedSummary listLastModified(@PathParam("project") String project,
+    LastModified listLastModified(@PathParam("project") String project,
             @PathParam("repo") String repo,
             @QueryParam("at") String commitIdOrRef);
 
@@ -123,8 +123,8 @@ public interface FileApi {
     @Path("/rest/api/{jclouds.api-version}/projects/{project}/repos/{repo}/last-modified/{path}")
     @Fallback(BitbucketFallbacks.LastModifiedSummaryOnError.class)
     @GET
-    LastModifiedSummary listLastModified(@PathParam("project") String project,
-             @PathParam("repo") String repo,
-             @PathParam("path") String path,
-             @QueryParam("at") String commitIdOrRef);
+    LastModified listLastModified(@PathParam("project") String project,
+            @PathParam("repo") String repo,
+            @PathParam("path") String path,
+            @QueryParam("at") String commitIdOrRef);
 }

--- a/src/main/java/com/cdancy/bitbucket/rest/features/FileApi.java
+++ b/src/main/java/com/cdancy/bitbucket/rest/features/FileApi.java
@@ -20,6 +20,7 @@ package com.cdancy.bitbucket.rest.features;
 import com.cdancy.bitbucket.rest.annotations.Documentation;
 import com.cdancy.bitbucket.rest.domain.commit.Commit;
 import com.cdancy.bitbucket.rest.domain.file.FilesPage;
+import com.cdancy.bitbucket.rest.domain.file.LastModifiedSummary;
 import com.cdancy.bitbucket.rest.domain.file.LinePage;
 import com.cdancy.bitbucket.rest.domain.file.RawContent;
 import com.cdancy.bitbucket.rest.fallbacks.BitbucketFallbacks;
@@ -103,4 +104,27 @@ public interface FileApi {
                            @Nullable @QueryParam("at") String commitIdOrRef,
                            @Nullable @QueryParam("start") Integer start,
                            @Nullable @QueryParam("limit") Integer limit);
+
+    @Named("file:last-modified")
+    @Documentation({"https://docs.atlassian.com/bitbucket-server/rest/6.0.0/bitbucket-rest.html#idp231"})
+    @Produces(MediaType.APPLICATION_JSON)
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Path("/rest/api/{jclouds.api-version}/projects/{project}/repos/{repo}/last-modified")
+    @Fallback(BitbucketFallbacks.LastModifiedSummaryOnError.class)
+    @GET
+    LastModifiedSummary listLastModified(@PathParam("project") String project,
+            @PathParam("repo") String repo,
+            @QueryParam("at") String commitIdOrRef);
+
+    @Named("file:last-modified")
+    @Documentation({"https://docs.atlassian.com/bitbucket-server/rest/6.0.0/bitbucket-rest.html#idp233"})
+    @Produces(MediaType.APPLICATION_JSON)
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Path("/rest/api/{jclouds.api-version}/projects/{project}/repos/{repo}/last-modified/{path}")
+    @Fallback(BitbucketFallbacks.LastModifiedSummaryOnError.class)
+    @GET
+    LastModifiedSummary listLastModified(@PathParam("project") String project,
+             @PathParam("repo") String repo,
+             @PathParam("path") String path,
+             @QueryParam("at") String commitIdOrRef);
 }

--- a/src/test/java/com/cdancy/bitbucket/rest/features/FileApiLiveTest.java
+++ b/src/test/java/com/cdancy/bitbucket/rest/features/FileApiLiveTest.java
@@ -26,7 +26,7 @@ import com.cdancy.bitbucket.rest.domain.branch.BranchPage;
 import com.cdancy.bitbucket.rest.domain.commit.Commit;
 import com.cdancy.bitbucket.rest.domain.commit.CommitPage;
 import com.cdancy.bitbucket.rest.domain.file.FilesPage;
-import com.cdancy.bitbucket.rest.domain.file.LastModifiedSummary;
+import com.cdancy.bitbucket.rest.domain.file.LastModified;
 import com.cdancy.bitbucket.rest.domain.file.Line;
 import com.cdancy.bitbucket.rest.domain.file.LinePage;
 import com.cdancy.bitbucket.rest.domain.file.RawContent;
@@ -251,7 +251,7 @@ public class FileApiLiveTest extends BaseBitbucketApiLiveTest {
     public void lastModified() {
         final CommitPage commits = api.commitsApi().list(projectKey, repoKey, null, null, null, null, null, null, null, 1, null);
         final Commit commit = commits.values().get(0);
-        final LastModifiedSummary summary = api.fileApi().listLastModified(projectKey, repoKey, branch);
+        final LastModified summary = api.fileApi().listLastModified(projectKey, repoKey, branch);
 
         assertThat(summary).isNotNull();
         assertThat(summary.latestCommit()).isNotNull();
@@ -266,7 +266,7 @@ public class FileApiLiveTest extends BaseBitbucketApiLiveTest {
         final String fileContent = UUID.randomUUID().toString();
         final Commit commit = api.fileApi().updateContent(projectKey, repoKey, newDirectory + "/" + readmeFilePath,
                 branch, fileContent, message, null, null);
-        final LastModifiedSummary summary = api.fileApi().listLastModified(projectKey, repoKey, newDirectory, branch);
+        final LastModified summary = api.fileApi().listLastModified(projectKey, repoKey, newDirectory, branch);
 
         assertThat(summary).isNotNull();
         assertThat(summary.latestCommit()).isNotNull();
@@ -280,7 +280,7 @@ public class FileApiLiveTest extends BaseBitbucketApiLiveTest {
     public void lastModifiedGivenEmptyRepository() {
         final String emptyRepository = "lastModifiedGivenEmptyRepository";
         api.repositoryApi().create(projectKey, CreateRepository.create(emptyRepository, false));
-        final LastModifiedSummary summary = api.fileApi().listLastModified(projectKey, emptyRepository, branch);
+        final LastModified summary = api.fileApi().listLastModified(projectKey, emptyRepository, branch);
         assertThat(summary).isNotNull();
         assertThat(summary.errors().isEmpty()).isFalse();
 
@@ -289,7 +289,7 @@ public class FileApiLiveTest extends BaseBitbucketApiLiveTest {
 
     @Test
     public void lastModifiedAtPathGivenInvalidPath() {
-        final LastModifiedSummary summary = api.fileApi().listLastModified(projectKey, repoKey, readmeFilePath, branch);
+        final LastModified summary = api.fileApi().listLastModified(projectKey, repoKey, readmeFilePath, branch);
         assertThat(summary).isNotNull();
         assertThat(summary.errors().isEmpty()).isFalse();
     }

--- a/src/test/java/com/cdancy/bitbucket/rest/features/FileApiLiveTest.java
+++ b/src/test/java/com/cdancy/bitbucket/rest/features/FileApiLiveTest.java
@@ -26,10 +26,12 @@ import com.cdancy.bitbucket.rest.domain.branch.BranchPage;
 import com.cdancy.bitbucket.rest.domain.commit.Commit;
 import com.cdancy.bitbucket.rest.domain.commit.CommitPage;
 import com.cdancy.bitbucket.rest.domain.file.FilesPage;
+import com.cdancy.bitbucket.rest.domain.file.LastModifiedSummary;
 import com.cdancy.bitbucket.rest.domain.file.Line;
 import com.cdancy.bitbucket.rest.domain.file.LinePage;
 import com.cdancy.bitbucket.rest.domain.file.RawContent;
 import com.cdancy.bitbucket.rest.domain.pullrequest.ChangePage;
+import com.cdancy.bitbucket.rest.options.CreateRepository;
 import com.google.common.collect.Lists;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
@@ -57,9 +59,9 @@ public class FileApiLiveTest extends BaseBitbucketApiLiveTest {
     @BeforeClass
     public void init() {
         generatedTestContents = TestUtilities.initGeneratedTestContents(this.endpoint, this.bitbucketAuthentication, this.api);
-        this.projectKey = "test";
-        this.repoKey = "yvbvgbmzdz";
-        
+        this.projectKey = generatedTestContents.project.name();
+        this.repoKey = generatedTestContents.repository.name();
+
         final CommitPage commitPage = api.commitsApi().list(projectKey, repoKey, true, null, null, null, null, null, null, 10, null);
         assertThat(commitPage).isNotNull();
         assertThat(commitPage.errors().isEmpty()).isTrue();
@@ -243,6 +245,53 @@ public class FileApiLiveTest extends BaseBitbucketApiLiveTest {
         assertThat(possibleContent.value()).isNull();
         assertThat(possibleContent.errors().isEmpty()).isFalse();
         assertThat(possibleContent.errors().get(0).message()).isEqualTo("Failed retrieving raw content");
+    }
+
+    @Test (dependsOnMethods = "updateContentCreateFile")
+    public void lastModified() {
+        final CommitPage commits = api.commitsApi().list(projectKey, repoKey, null, null, null, null, null, null, null, 1, null);
+        final Commit commit = commits.values().get(0);
+        final LastModifiedSummary summary = api.fileApi().listLastModified(projectKey, repoKey, branch);
+
+        assertThat(summary).isNotNull();
+        assertThat(summary.latestCommit()).isNotNull();
+        assertThat(summary.latestCommit().id()).isEqualTo(commit.id());
+        assertThat(summary.files()).isNotEmpty();
+        assertThat(summary.files().keySet().contains(readmeFilePath)).isTrue();
+    }
+
+    @Test (dependsOnMethods = "updateContentCreateFile")
+    public void lastModifiedAtPath() {
+        final String newDirectory = "newDirectory";
+        final String fileContent = UUID.randomUUID().toString();
+        final Commit commit = api.fileApi().updateContent(projectKey, repoKey, newDirectory + "/" + readmeFilePath,
+                branch, fileContent, message, null, null);
+        final LastModifiedSummary summary = api.fileApi().listLastModified(projectKey, repoKey, newDirectory, branch);
+
+        assertThat(summary).isNotNull();
+        assertThat(summary.latestCommit()).isNotNull();
+        assertThat(summary.latestCommit().id()).isEqualTo(commit.id());
+        assertThat(summary.files()).isNotEmpty();
+        assertThat(summary.files().keySet().contains(readmeFilePath)).isTrue();
+        assertThat(summary.files().get(readmeFilePath).id()).isEqualTo(commit.id());
+    }
+
+    @Test
+    public void lastModifiedGivenEmptyRepository() {
+        final String emptyRepository = "lastModifiedGivenEmptyRepository";
+        api.repositoryApi().create(projectKey, CreateRepository.create(emptyRepository, false));
+        final LastModifiedSummary summary = api.fileApi().listLastModified(projectKey, emptyRepository, branch);
+        assertThat(summary).isNotNull();
+        assertThat(summary.errors().isEmpty()).isFalse();
+
+        generatedTestContents.addRepoForDeletion(projectKey, emptyRepository);
+    }
+
+    @Test
+    public void lastModifiedAtPathGivenInvalidPath() {
+        final LastModifiedSummary summary = api.fileApi().listLastModified(projectKey, repoKey, readmeFilePath, branch);
+        assertThat(summary).isNotNull();
+        assertThat(summary.errors().isEmpty()).isFalse();
     }
     
     @AfterClass

--- a/src/test/java/com/cdancy/bitbucket/rest/features/FileApiMockTest.java
+++ b/src/test/java/com/cdancy/bitbucket/rest/features/FileApiMockTest.java
@@ -20,7 +20,7 @@ package com.cdancy.bitbucket.rest.features;
 import com.cdancy.bitbucket.rest.BitbucketApi;
 import com.cdancy.bitbucket.rest.BitbucketApiMetadata;
 import com.cdancy.bitbucket.rest.domain.commit.Commit;
-import com.cdancy.bitbucket.rest.domain.file.LastModifiedSummary;
+import com.cdancy.bitbucket.rest.domain.file.LastModified;
 import com.cdancy.bitbucket.rest.domain.file.LinePage;
 import com.cdancy.bitbucket.rest.domain.file.RawContent;
 import com.cdancy.bitbucket.rest.BaseBitbucketMockTest;
@@ -237,7 +237,7 @@ public class FileApiMockTest extends BaseBitbucketMockTest {
 
         server.enqueue(new MockResponse().setBody(payloadFromResource("/last-modified-summary.json")).setResponseCode(200));
         try (final BitbucketApi baseApi = api(server.getUrl("/"));) {
-            LastModifiedSummary summary = baseApi.fileApi().listLastModified(projectKey, repoKey, branch);
+            LastModified summary = baseApi.fileApi().listLastModified(projectKey, repoKey, branch);
             assertThat(summary).isNotNull();
             assertThat(summary.latestCommit()).isNotNull();
             assertThat(summary.files().isEmpty()).isFalse();
@@ -254,7 +254,7 @@ public class FileApiMockTest extends BaseBitbucketMockTest {
 
         server.enqueue(new MockResponse().setBody(payloadFromResource("/last-modified-summary.json")).setResponseCode(200));
         try (final BitbucketApi baseApi = api(server.getUrl("/"));) {
-            LastModifiedSummary summary = baseApi.fileApi().listLastModified(projectKey, repoKey, directoryPath, branch);
+            LastModified summary = baseApi.fileApi().listLastModified(projectKey, repoKey, directoryPath, branch);
             assertThat(summary).isNotNull();
             assertThat(summary.latestCommit()).isNotNull();
             assertThat(summary.files().isEmpty()).isFalse();
@@ -271,8 +271,9 @@ public class FileApiMockTest extends BaseBitbucketMockTest {
 
         server.enqueue(new MockResponse().setBody(payloadFromResource("/errors.json")).setResponseCode(400));
         try (final BitbucketApi baseApi = api(server.getUrl("/"));) {
-            LastModifiedSummary summary = baseApi.fileApi().listLastModified(projectKey, repoKey, branch);
+            LastModified summary = baseApi.fileApi().listLastModified(projectKey, repoKey, branch);
             assertThat(summary).isNotNull();
+            assertThat(summary.files().isEmpty()).isTrue();
             assertThat(summary.errors().isEmpty()).isFalse();
             assertSent(server, getMethod, restApiPath + BitbucketApiMetadata.API_VERSION
                     + "/projects/" + projectKey + "/repos/" + repoKey + "/last-modified", Collections.singletonMap("at", branch));
@@ -286,8 +287,9 @@ public class FileApiMockTest extends BaseBitbucketMockTest {
 
         server.enqueue(new MockResponse().setBody(payloadFromResource("/errors.json")).setResponseCode(400));
         try (final BitbucketApi baseApi = api(server.getUrl("/"));) {
-            LastModifiedSummary summary = baseApi.fileApi().listLastModified(projectKey, repoKey, directoryPath, branch);
+            LastModified summary = baseApi.fileApi().listLastModified(projectKey, repoKey, directoryPath, branch);
             assertThat(summary).isNotNull();
+            assertThat(summary.files().isEmpty()).isTrue();
             assertThat(summary.errors().isEmpty()).isFalse();
             assertSent(server, getMethod, restApiPath + BitbucketApiMetadata.API_VERSION
                     + "/projects/" + projectKey + "/repos/" + repoKey + "/last-modified/" + directoryPath, Collections.singletonMap("at", branch));

--- a/src/test/java/com/cdancy/bitbucket/rest/features/FileApiMockTest.java
+++ b/src/test/java/com/cdancy/bitbucket/rest/features/FileApiMockTest.java
@@ -20,6 +20,7 @@ package com.cdancy.bitbucket.rest.features;
 import com.cdancy.bitbucket.rest.BitbucketApi;
 import com.cdancy.bitbucket.rest.BitbucketApiMetadata;
 import com.cdancy.bitbucket.rest.domain.commit.Commit;
+import com.cdancy.bitbucket.rest.domain.file.LastModifiedSummary;
 import com.cdancy.bitbucket.rest.domain.file.LinePage;
 import com.cdancy.bitbucket.rest.domain.file.RawContent;
 import com.cdancy.bitbucket.rest.BaseBitbucketMockTest;
@@ -27,6 +28,8 @@ import com.cdancy.bitbucket.rest.domain.file.FilesPage;
 import com.google.common.collect.ImmutableMap;
 import com.squareup.okhttp.mockwebserver.MockResponse;
 import com.squareup.okhttp.mockwebserver.MockWebServer;
+
+import java.util.Collections;
 import java.util.Map;
 import org.testng.annotations.Test;
 
@@ -38,6 +41,7 @@ public class FileApiMockTest extends BaseBitbucketMockTest {
     private final String projectKey = "PRJ";
     private final String repoKey = "myrepo";
     private final String filePath = "some/random/path/MyFile.txt";
+    private final String directoryPath = "some/random/path";
     private final String restApiPath = "/rest/api/";
     private final String branch = "myBranch";
     private final String content = "file contents";
@@ -224,6 +228,70 @@ public class FileApiMockTest extends BaseBitbucketMockTest {
                     + "/projects/PRJ/repos/myrepo/files", queryParams);
         } finally {
             baseApi.close();
+            server.shutdown();
+        }
+    }
+
+    public void testLastModified() throws Exception {
+        final MockWebServer server = mockWebServer();
+
+        server.enqueue(new MockResponse().setBody(payloadFromResource("/last-modified-summary.json")).setResponseCode(200));
+        try (final BitbucketApi baseApi = api(server.getUrl("/"));) {
+            LastModifiedSummary summary = baseApi.fileApi().listLastModified(projectKey, repoKey, branch);
+            assertThat(summary).isNotNull();
+            assertThat(summary.latestCommit()).isNotNull();
+            assertThat(summary.files().isEmpty()).isFalse();
+            assertThat(summary.errors().isEmpty()).isTrue();
+            assertSent(server, getMethod, restApiPath + BitbucketApiMetadata.API_VERSION
+                    + "/projects/" + projectKey + "/repos/" + repoKey + "/last-modified", Collections.singletonMap("at", branch));
+        } finally {
+            server.shutdown();
+        }
+    }
+
+    public void testLastModifiedAtPath() throws Exception {
+        final MockWebServer server = mockWebServer();
+
+        server.enqueue(new MockResponse().setBody(payloadFromResource("/last-modified-summary.json")).setResponseCode(200));
+        try (final BitbucketApi baseApi = api(server.getUrl("/"));) {
+            LastModifiedSummary summary = baseApi.fileApi().listLastModified(projectKey, repoKey, directoryPath, branch);
+            assertThat(summary).isNotNull();
+            assertThat(summary.latestCommit()).isNotNull();
+            assertThat(summary.files().isEmpty()).isFalse();
+            assertThat(summary.errors().isEmpty()).isTrue();
+            assertSent(server, getMethod, restApiPath + BitbucketApiMetadata.API_VERSION
+                    + "/projects/" + projectKey + "/repos/" + repoKey + "/last-modified/" + directoryPath, Collections.singletonMap("at", branch));
+        } finally {
+            server.shutdown();
+        }
+    }
+
+    public void testLastModifiedBadRequest() throws Exception {
+        final MockWebServer server = mockWebServer();
+
+        server.enqueue(new MockResponse().setBody(payloadFromResource("/errors.json")).setResponseCode(400));
+        try (final BitbucketApi baseApi = api(server.getUrl("/"));) {
+            LastModifiedSummary summary = baseApi.fileApi().listLastModified(projectKey, repoKey, branch);
+            assertThat(summary).isNotNull();
+            assertThat(summary.errors().isEmpty()).isFalse();
+            assertSent(server, getMethod, restApiPath + BitbucketApiMetadata.API_VERSION
+                    + "/projects/" + projectKey + "/repos/" + repoKey + "/last-modified", Collections.singletonMap("at", branch));
+        } finally {
+            server.shutdown();
+        }
+    }
+
+    public void testLastModifiedAtPathBadRequest() throws Exception {
+        final MockWebServer server = mockWebServer();
+
+        server.enqueue(new MockResponse().setBody(payloadFromResource("/errors.json")).setResponseCode(400));
+        try (final BitbucketApi baseApi = api(server.getUrl("/"));) {
+            LastModifiedSummary summary = baseApi.fileApi().listLastModified(projectKey, repoKey, directoryPath, branch);
+            assertThat(summary).isNotNull();
+            assertThat(summary.errors().isEmpty()).isFalse();
+            assertSent(server, getMethod, restApiPath + BitbucketApiMetadata.API_VERSION
+                    + "/projects/" + projectKey + "/repos/" + repoKey + "/last-modified/" + directoryPath, Collections.singletonMap("at", branch));
+        } finally {
             server.shutdown();
         }
     }

--- a/src/test/resources/last-modified-summary.json
+++ b/src/test/resources/last-modified-summary.json
@@ -1,0 +1,67 @@
+{
+  "files": {
+    "pom.xml": {
+      "id": "def0123abcdef4567abcdef8987abcdef6543abc",
+      "displayId": "def0123abcd",
+      "author": {
+        "name": "charlie",
+        "emailAddress": "charlie@example.com"
+      },
+      "authorTimestamp": 1549862602763,
+      "committer": {
+        "name": "charlie",
+        "emailAddress": "charlie@example.com"
+      },
+      "committerTimestamp": 1549862602763,
+      "message": "More work on feature 1",
+      "parents": [
+        {
+          "id": "abcdef0123abcdef4567abcdef8987abcdef6543",
+          "displayId": "abcdef0"
+        }
+      ]
+    },
+    "README.md": {
+      "id": "abcdef0123abcdef4567abcdef8987abcdef6543",
+      "displayId": "abcdef0123a",
+      "author": {
+        "name": "charlie",
+        "emailAddress": "charlie@example.com"
+      },
+      "authorTimestamp": 1549862602763,
+      "committer": {
+        "name": "charlie",
+        "emailAddress": "charlie@example.com"
+      },
+      "committerTimestamp": 1549862602763,
+      "message": "WIP on feature 1",
+      "parents": [
+        {
+          "id": "abcdef0123abcdef4567abcdef8987abcdef6543",
+          "displayId": "abcdef0"
+        }
+      ]
+    }
+  },
+  "latestCommit": {
+    "id": "def0123abcdef4567abcdef8987abcdef6543abc",
+    "displayId": "def0123abcd",
+    "author": {
+      "name": "charlie",
+      "emailAddress": "charlie@example.com"
+    },
+    "authorTimestamp": 1549862602763,
+    "committer": {
+      "name": "charlie",
+      "emailAddress": "charlie@example.com"
+    },
+    "committerTimestamp": 1549862602763,
+    "message": "More work on feature 1",
+    "parents": [
+      {
+        "id": "abcdef0123abcdef4567abcdef8987abcdef6543",
+        "displayId": "abcdef0"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Note the API [documentation](https://docs.atlassian.com/bitbucket-server/rest/6.0.0/bitbucket-rest.html#idp231) reads as if the "at" query parameter is optional. It says it will use the default branch. However, when writing integration tests, I always got an `com.atlassian.bitbucket.validation.ArgumentValidationException` when I excluded it saying "Streaming modifications requires a starting commit." so I made it required.