### PR TITLE
RepositoryApi: Listing all repos regardless of project ( copy of #191) 

### DIFF
--- a/src/main/java/com/cdancy/bitbucket/rest/features/RepositoryApi.java
+++ b/src/main/java/com/cdancy/bitbucket/rest/features/RepositoryApi.java
@@ -111,8 +111,8 @@ public interface RepositoryApi {
     @Path("/repos")
     @Fallback(BitbucketFallbacks.RepositoryPageOnError.class)
     @GET
-    RepositoryPage listAll(@Nullable @QueryParam("name") String name,
-                           @Nullable @QueryParam("projectname") String projectName,
+    RepositoryPage listAll(@Nullable @QueryParam("projectname") String project,
+                           @Nullable @QueryParam("name") String repo,
                            @Nullable @QueryParam("permission") String permission,
                            @Nullable @QueryParam("visibility") String visibility,
                            @Nullable @QueryParam("start") Integer start,

--- a/src/main/java/com/cdancy/bitbucket/rest/features/RepositoryApi.java
+++ b/src/main/java/com/cdancy/bitbucket/rest/features/RepositoryApi.java
@@ -51,14 +51,14 @@ import org.jclouds.rest.annotations.ResponseParser;
 
 @Produces(MediaType.APPLICATION_JSON)
 @RequestFilters(BitbucketAuthenticationFilter.class)
-@Path("/rest/api/{jclouds.api-version}/projects")
+@Path("/rest/api/{jclouds.api-version}")
 @SuppressWarnings("PMD.AvoidDuplicateLiterals")
 public interface RepositoryApi {
 
     @Named("repository:create")
     @Documentation({"https://developer.atlassian.com/static/rest/bitbucket-server/latest/bitbucket-rest.html#idm45888277587248"})
     @Consumes(MediaType.APPLICATION_JSON)
-    @Path("/{project}/repos")
+    @Path("/projects/{project}/repos")
     @Fallback(BitbucketFallbacks.RepositoryOnError.class)
     @POST
     Repository create(@PathParam("project") String project,
@@ -67,7 +67,7 @@ public interface RepositoryApi {
     @Named("repository:get")
     @Documentation({"https://developer.atlassian.com/static/rest/bitbucket-server/latest/bitbucket-rest.html#idm45888277593152"})
     @Consumes(MediaType.APPLICATION_JSON)
-    @Path("/{project}/repos/{repo}")
+    @Path("/projects/{project}/repos/{repo}")
     @Fallback(BitbucketFallbacks.RepositoryOnError.class)
     @GET
     Repository get(@PathParam("project") String project,
@@ -76,7 +76,7 @@ public interface RepositoryApi {
     @Named("repository:fork")
     @Documentation({"https://developer.atlassian.com/static/rest/bitbucket-server/latest/bitbucket-rest.html#idm45888277587248"})
     @Consumes(MediaType.APPLICATION_JSON)
-    @Path("/{project}/repos/{repo}")
+    @Path("/projects/{project}/repos/{repo}")
     @Payload("%7B \"name\": \"{newRepo}\", \"project\": %7B \"key\": \"{newProject}\" %7D %7D")
     @Fallback(BitbucketFallbacks.RepositoryOnError.class)
     @POST
@@ -88,7 +88,7 @@ public interface RepositoryApi {
     @Named("repository:delete")
     @Documentation({"https://developer.atlassian.com/static/rest/bitbucket-server/latest/bitbucket-rest.html#idm45888277567792"})
     @Consumes(MediaType.APPLICATION_JSON)
-    @Path("/{project}/repos/{repo}")
+    @Path("/projects/{project}/repos/{repo}")
     @Fallback(BitbucketFallbacks.RequestStatusOnError.class)
     @ResponseParser(DeleteRepositoryParser.class)
     @DELETE
@@ -98,17 +98,30 @@ public interface RepositoryApi {
     @Named("repository:list")
     @Documentation({"https://developer.atlassian.com/static/rest/bitbucket-server/latest/bitbucket-rest.html#idm45888277593152"})
     @Consumes(MediaType.APPLICATION_JSON)
-    @Path("/{project}/repos")
+    @Path("/projects/{project}/repos")
     @Fallback(BitbucketFallbacks.RepositoryPageOnError.class)
     @GET
     RepositoryPage list(@PathParam("project") String project,
                         @Nullable @QueryParam("start") Integer start,
                         @Nullable @QueryParam("limit") Integer limit);
 
+    @Named("repository:list-all")
+    @Documentation({"https://docs.atlassian.com/bitbucket-server/rest/5.0.0/bitbucket-rest.html#idm45659055274784"})
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Path("/repos")
+    @Fallback(BitbucketFallbacks.RepositoryPageOnError.class)
+    @GET
+    RepositoryPage listAll(@Nullable @QueryParam("name") String name,
+                           @Nullable @QueryParam("projectname") String projectName,
+                           @Nullable @QueryParam("permission") String permission,
+                           @Nullable @QueryParam("visibility") String visibility,
+                           @Nullable @QueryParam("start") Integer start,
+                           @Nullable @QueryParam("limit") Integer limit);
+
     @Named("repository:get-pullrequest-settings")
     @Documentation({"https://developer.atlassian.com/static/rest/bitbucket-server/5.0.0/bitbucket-rest.html#idm45659054915136"})
     @Consumes(MediaType.APPLICATION_JSON)
-    @Path("/{project}/repos/{repo}/settings/pull-requests")
+    @Path("/projects/{project}/repos/{repo}/settings/pull-requests")
     @Fallback(BitbucketFallbacks.PullRequestSettingsOnError.class)
     @GET
     PullRequestSettings getPullRequestSettings(@PathParam("project") String project,
@@ -117,7 +130,7 @@ public interface RepositoryApi {
     @Named("repository:update-pullrequest-settings")
     @Documentation({"https://developer.atlassian.com/static/rest/bitbucket-server/5.0.0/bitbucket-rest.html#idm45659054915136"})
     @Consumes(MediaType.APPLICATION_JSON)
-    @Path("/{project}/repos/{repo}/settings/pull-requests")
+    @Path("/projects/{project}/repos/{repo}/settings/pull-requests")
     @Fallback(BitbucketFallbacks.PullRequestSettingsOnError.class)
     @POST
     PullRequestSettings updatePullRequestSettings(@PathParam("project") String project,
@@ -127,7 +140,7 @@ public interface RepositoryApi {
     @Named("repository:create-permissions-by-user")
     @Documentation({"https://developer.atlassian.com/static/rest/bitbucket-server/5.0.0/bitbucket-rest.html#idm45659054938032"})
     @Consumes(MediaType.APPLICATION_JSON)
-    @Path("/{project}/repos/{repo}/permissions/users")
+    @Path("/projects/{project}/repos/{repo}/permissions/users")
     @Fallback(BitbucketFallbacks.RequestStatusOnError.class)
     @ResponseParser(RequestStatusParser.class)
     @PUT
@@ -139,7 +152,7 @@ public interface RepositoryApi {
     @Named("repository:delete-permissions-by-user")
     @Documentation({"https://developer.atlassian.com/static/rest/bitbucket-server/5.0.0/bitbucket-rest.html#idm45659054938032"})
     @Consumes(MediaType.APPLICATION_JSON)
-    @Path("/{project}/repos/{repo}/permissions/users")
+    @Path("/projects/{project}/repos/{repo}/permissions/users")
     @Fallback(BitbucketFallbacks.RequestStatusOnError.class)
     @ResponseParser(RequestStatusParser.class)
     @DELETE
@@ -150,7 +163,7 @@ public interface RepositoryApi {
     @Named("repository:list-permissions-by-user")
     @Documentation({"https://developer.atlassian.com/static/rest/bitbucket-server/5.0.0/bitbucket-rest.html#idm45659054938032"})
     @Consumes(MediaType.APPLICATION_JSON)
-    @Path("/{project}/repos/{repo}/permissions/users")
+    @Path("/projects/{project}/repos/{repo}/permissions/users")
     @Fallback(BitbucketFallbacks.PermissionsPageOnError.class)
     @GET
     PermissionsPage listPermissionsByUser(@PathParam("project") String project,
@@ -161,7 +174,7 @@ public interface RepositoryApi {
     @Named("repository:create-permissions-by-group")
     @Documentation({"https://developer.atlassian.com/static/rest/bitbucket-server/5.0.0/bitbucket-rest.html#idm45659054969200"})
     @Consumes(MediaType.APPLICATION_JSON)
-    @Path("/{project}/repos/{repo}/permissions/groups")
+    @Path("/projects/{project}/repos/{repo}/permissions/groups")
     @Fallback(BitbucketFallbacks.RequestStatusOnError.class)
     @ResponseParser(RequestStatusParser.class)
     @PUT
@@ -173,7 +186,7 @@ public interface RepositoryApi {
     @Named("repository:delete-permissions-by-group")
     @Documentation({"https://developer.atlassian.com/static/rest/bitbucket-server/5.0.0/bitbucket-rest.html#idm45659054969200"})
     @Consumes(MediaType.APPLICATION_JSON)
-    @Path("/{project}/repos/{repo}/permissions/groups")
+    @Path("/projects/{project}/repos/{repo}/permissions/groups")
     @Fallback(BitbucketFallbacks.RequestStatusOnError.class)
     @ResponseParser(RequestStatusParser.class)
     @DELETE
@@ -184,7 +197,7 @@ public interface RepositoryApi {
     @Named("repository:list-permissions-by-group")
     @Documentation({"https://developer.atlassian.com/static/rest/bitbucket-server/5.0.0/bitbucket-rest.html#idm45659054969200"})
     @Consumes(MediaType.APPLICATION_JSON)
-    @Path("/{project}/repos/{repo}/permissions/groups")
+    @Path("/projects/{project}/repos/{repo}/permissions/groups")
     @Fallback(BitbucketFallbacks.PermissionsPageOnError.class)
     @GET
     PermissionsPage listPermissionsByGroup(@PathParam("project") String project,

--- a/src/test/java/com/cdancy/bitbucket/rest/features/RepositoryApiLiveTest.java
+++ b/src/test/java/com/cdancy/bitbucket/rest/features/RepositoryApiLiveTest.java
@@ -106,6 +106,25 @@ public class RepositoryApiLiveTest extends BaseBitbucketApiLiveTest {
     }
 
     @Test
+    public void testListAllRepositories() {
+        final RepositoryPage repositoryPage = api().listAll(null, null, null, null, 0, 100);
+
+        assertThat(repositoryPage).isNotNull();
+        assertThat(repositoryPage.errors()).isEmpty();
+        assertThat(repositoryPage.size()).isGreaterThan(0);
+
+        assertThat(repositoryPage.values()).isNotEmpty();
+        boolean found = false;
+        for (final Repository possibleRepo : repositoryPage.values()) {
+            if (possibleRepo.name().equals(repoKey)) {
+                found = true;
+                break;
+            }
+        }
+        assertThat(found).isTrue();
+    }
+
+    @Test
     public void testDeleteRepositoryNonExistent() {
         final String random = randomStringLettersOnly();
         final RequestStatus success = api().delete(projectKey, random);

--- a/src/test/java/com/cdancy/bitbucket/rest/features/RepositoryApiLiveTest.java
+++ b/src/test/java/com/cdancy/bitbucket/rest/features/RepositoryApiLiveTest.java
@@ -61,7 +61,7 @@ public class RepositoryApiLiveTest extends BaseBitbucketApiLiveTest {
         this.user = TestUtilities.getDefaultUser(this.bitbucketAuthentication, this.api);
     }
 
-    @Test 
+    @Test
     public void testGetRepository() {
         final Repository repository = api().get(projectKey, repoKey);
         assertThat(repository).isNotNull();
@@ -125,6 +125,38 @@ public class RepositoryApiLiveTest extends BaseBitbucketApiLiveTest {
     }
 
     @Test
+    public void testListAllRepositoriesByRepository() {
+        final RepositoryPage repositoryPage = api().listAll(null, repoKey, null, null, 0, 100);
+
+        assertThat(repositoryPage).isNotNull();
+        assertThat(repositoryPage.errors()).isEmpty();
+        assertThat(repositoryPage.size()).isEqualTo(1);
+
+        assertThat(repositoryPage.values()).isNotEmpty();
+        assertThat(repositoryPage.values().get(0).name()).isEqualTo(repoKey);
+    }
+
+    @Test
+    public void testListAllRepositoriesByProjectNonExistent() {
+        final String projectKey = "HelloWorld";
+        final RepositoryPage repositoryPage = api().listAll(projectKey, null, null, null, 0, 100);
+        assertThat(repositoryPage).isNotNull();
+        assertThat(repositoryPage.errors()).isEmpty();
+        assertThat(repositoryPage.size()).isEqualTo(0);
+        assertThat(repositoryPage.values()).isEmpty();
+    }
+
+    @Test
+    public void testListAllRepositoriesByRepositoryNonExistent() {
+        final String repoKey = "HelloWorld";
+        final RepositoryPage repositoryPage = api().listAll(null, repoKey, null, null, 0, 100);
+        assertThat(repositoryPage).isNotNull();
+        assertThat(repositoryPage.errors()).isEmpty();
+        assertThat(repositoryPage.size()).isEqualTo(0);
+        assertThat(repositoryPage.values()).isEmpty();
+    }
+
+    @Test
     public void testDeleteRepositoryNonExistent() {
         final String random = randomStringLettersOnly();
         final RequestStatus success = api().delete(projectKey, random);
@@ -162,7 +194,7 @@ public class RepositoryApiLiveTest extends BaseBitbucketApiLiveTest {
         assertThat(settings.mergeConfig().strategies()).isNotEmpty();
         assertThat(MergeStrategy.MergeStrategyId.SQUASH.equals(settings.mergeConfig().defaultStrategy().id()));
     }
-    
+
     @Test (dependsOnMethods = "testUpdatePullRequestSettings")
     public void testGetPullRequestSettings() {
         final PullRequestSettings settings = api().getPullRequestSettings(projectKey, repoKey);
@@ -176,9 +208,9 @@ public class RepositoryApiLiveTest extends BaseBitbucketApiLiveTest {
         final RequestStatus success = api().createPermissionsByUser(projectKey, repoKey, repoWriteKeyword, user.slug());
         assertThat(success).isNotNull();
         assertThat(success.value()).isTrue();
-        assertThat(success.errors()).isEmpty(); 
+        assertThat(success.errors()).isEmpty();
     }
-    
+
     @Test(dependsOnMethods = "testCreatePermissionByUser")
     public void testListPermissionByUser() {
         final PermissionsPage permissionsPage = api().listPermissionsByUser(projectKey, repoKey, 0, 100);
@@ -192,7 +224,7 @@ public class RepositoryApiLiveTest extends BaseBitbucketApiLiveTest {
         assertThat(success.value()).isTrue();
         assertThat(success.errors()).isEmpty();
     }
-    
+
     @Test(dependsOnMethods = {testGetRepoKeyword})
     public void testCreatePermissionByGroup() {
         final RequestStatus success = api().createPermissionsByGroup(projectKey, repoKey, repoWriteKeyword, defaultBitbucketGroup);
@@ -200,13 +232,13 @@ public class RepositoryApiLiveTest extends BaseBitbucketApiLiveTest {
         assertThat(success.value()).isTrue();
         assertThat(success.errors()).isEmpty();
     }
-    
+
     @Test(dependsOnMethods = "testCreatePermissionByGroup")
     public void testListPermissionByGroup() {
         final PermissionsPage permissionsPage = api().listPermissionsByGroup(projectKey, repoKey, 0, 100);
         assertThat(permissionsPage.values()).isNotEmpty();
     }
-    
+
     @Test(dependsOnMethods = {"testListPermissionByGroup"})
     public void testDeletePermissionByGroup() {
         final RequestStatus success = api().deletePermissionsByGroup(projectKey, repoKey, defaultBitbucketGroup);
@@ -236,7 +268,7 @@ public class RepositoryApiLiveTest extends BaseBitbucketApiLiveTest {
         final RequestStatus success = api().createPermissionsByUser(projectKey, repoKey, repoWriteKeyword, TestUtilities.randomString());
         assertThat(success).isNotNull();
         assertThat(success.value()).isFalse();
-        assertThat(success.errors()).isNotEmpty();    
+        assertThat(success.errors()).isNotEmpty();
     }
 
     @Test(dependsOnMethods = {testGetRepoKeyword})

--- a/src/test/java/com/cdancy/bitbucket/rest/features/RepositoryApiMockTest.java
+++ b/src/test/java/com/cdancy/bitbucket/rest/features/RepositoryApiMockTest.java
@@ -392,16 +392,15 @@ public class RepositoryApiMockTest extends BaseBitbucketMockTest {
         final MockWebServer server = mockWebServer();
 
         server.enqueue(new MockResponse().setBody(payloadFromResource("/repository-page-single.json"))
-            .setResponseCode(200));
+                .setResponseCode(200));
         try (final BitbucketApi baseApi = api(server.getUrl("/"))) {
             final RepositoryApi api = baseApi.repositoryApi();
 
             final RepositoryPage repositoryPage = api.listAll(projectKey, null, null, null, null, null);
 
-            final Map<String, ?> queryParams =
-                ImmutableMap.of(projectKeyword, projectKey);
+            final Map<String, ?> queryParams = ImmutableMap.of(projectKeyword, projectKey);
             assertSent(server, getMethod, restApiPath + BitbucketApiMetadata.API_VERSION
-                + reposEndpoint, queryParams);
+                    + reposEndpoint, queryParams);
             assertThat(repositoryPage).isNotNull();
             assertThat(repositoryPage.errors()).isEmpty();
 
@@ -419,16 +418,15 @@ public class RepositoryApiMockTest extends BaseBitbucketMockTest {
         final MockWebServer server = mockWebServer();
 
         server.enqueue(new MockResponse().setBody(payloadFromResource("/repository-page-single.json"))
-            .setResponseCode(200));
+                .setResponseCode(200));
         try (final BitbucketApi baseApi = api(server.getUrl("/"))) {
             final RepositoryApi api = baseApi.repositoryApi();
 
             final RepositoryPage repositoryPage = api.listAll(null, repoKey, null, null, null, null);
 
-            final Map<String, ?> queryParams =
-                ImmutableMap.of(nameKeyword, repoKey);
+            final Map<String, ?> queryParams = ImmutableMap.of(nameKeyword, repoKey);
             assertSent(server, getMethod, restApiPath + BitbucketApiMetadata.API_VERSION
-                + reposEndpoint, queryParams);
+                    + reposEndpoint, queryParams);
             assertThat(repositoryPage).isNotNull();
             assertThat(repositoryPage.errors()).isEmpty();
 
@@ -445,16 +443,15 @@ public class RepositoryApiMockTest extends BaseBitbucketMockTest {
         final MockWebServer server = mockWebServer();
 
         server.enqueue(new MockResponse().setBody(payloadFromResource("/repository-page-empty.json"))
-            .setResponseCode(200));
+                .setResponseCode(200));
         try (final BitbucketApi baseApi = api(server.getUrl("/"))) {
             final RepositoryApi api = baseApi.repositoryApi();
 
             final RepositoryPage repositoryPage = api.listAll(projectKey, null, null, null, null, null);
 
-            final Map<String, ?> queryParams =
-                ImmutableMap.of(projectKeyword, projectKey);
+            final Map<String, ?> queryParams = ImmutableMap.of(projectKeyword, projectKey);
             assertSent(server, getMethod, restApiPath + BitbucketApiMetadata.API_VERSION
-                + reposEndpoint, queryParams);
+                    + reposEndpoint, queryParams);
             assertThat(repositoryPage).isNotNull();
             assertThat(repositoryPage.errors()).isEmpty();
 
@@ -471,16 +468,15 @@ public class RepositoryApiMockTest extends BaseBitbucketMockTest {
         final MockWebServer server = mockWebServer();
 
         server.enqueue(new MockResponse().setBody(payloadFromResource("/repository-page-empty.json"))
-            .setResponseCode(200));
+                .setResponseCode(200));
         try (final BitbucketApi baseApi = api(server.getUrl("/"))) {
             final RepositoryApi api = baseApi.repositoryApi();
 
             final RepositoryPage repositoryPage = api.listAll(null, repoKey, null, null, null, null);
 
-            final Map<String, ?> queryParams =
-                ImmutableMap.of(nameKeyword, repoKey);
+            final Map<String, ?> queryParams = ImmutableMap.of(nameKeyword, repoKey);
             assertSent(server, getMethod, restApiPath + BitbucketApiMetadata.API_VERSION
-                + reposEndpoint, queryParams);
+                    + reposEndpoint, queryParams);
             assertThat(repositoryPage).isNotNull();
             assertThat(repositoryPage.errors()).isEmpty();
 

--- a/src/test/resources/repository-page-empty.json
+++ b/src/test/resources/repository-page-empty.json
@@ -1,0 +1,7 @@
+{
+  "size": 0,
+  "limit": 25,
+  "start": 0,
+  "isLastPage": true,
+  "values": []
+}

--- a/src/test/resources/repository-page-single.json
+++ b/src/test/resources/repository-page-single.json
@@ -1,0 +1,50 @@
+{
+  "size": 1,
+  "limit": 25,
+  "start": 0,
+  "isLastPage": true,
+  "values": [
+    {
+      "slug": "my-repo",
+      "id": 1,
+      "name": "my-repo",
+      "scmId": "git",
+      "state": "AVAILABLE",
+      "statusMessage": "Available",
+      "forkable": true,
+      "project": {
+        "key": "PRJ",
+        "id": 1,
+        "name": "My Cool Project",
+        "description": "The description for my cool project.",
+        "public": true,
+        "type": "NORMAL",
+        "links": {
+          "self": [
+            {
+              "href": "http://link/to/project"
+            }
+          ]
+        }
+      },
+      "public": true,
+      "links": {
+        "clone": [
+          {
+            "href": "ssh://git@<baseURL>/PRJ/my-repo.git",
+            "name": "ssh"
+          },
+          {
+            "href": "https://<baseURL>/scm/PRJ/my-repo.git",
+            "name": "http"
+          }
+        ],
+        "self": [
+          {
+            "href": "http://link/to/repository"
+          }
+        ]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
- Update base path for RepositoryApi
- Create a new endpoint in RepositoryApi to list all repositories regardless of project

closes #190