### PR TITLE
Maven bintray readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Can be sourced from jcenter like so:
 	
 ### Maven repository Configuration:
 
-* Download a sample settings.xml file that has configured profile to pull from the correct maven repository using this link: [settings.xml](https://bintray.com/repo/downloadMavenRepoSettingsFile/downloadSettings?repoPath=%2Fcdancy%2Fjava-libraries)
+* Download a sample settings.xml file that has configured profile to pull from the correct maven repository using this link: [settings.xml](https://bintray.com/repo/downloadMavenRepoSettingsFile/downloadSettings?repoPath=%2Fbintray%2Fjcenter)
 
 **OR**
 
@@ -52,9 +52,9 @@ Can be sourced from jcenter like so:
         <snapshots>
           <enabled>false</enabled>
         </snapshots>
-        <id>bintray-cdancy-java-libraries</id>
+        <id>jcenter</id>
         <name>bintray</name>
-        <url>https://dl.bintray.com/cdancy/java-libraries</url>
+        <url>http://jcenter.bintray.com</url>
       </repository>
     </repositories>
 ```

--- a/README.md
+++ b/README.md
@@ -43,9 +43,11 @@ Can be sourced from jcenter like so:
 
 ### Maven repository Configuration:
 
-1. You can download a sample settings.xml file that has configured profile to pull from the correct maven repository using this link: [settings.xml](https://bintray.com/repo/downloadMavenRepoSettingsFile/downloadSettings?repoPath=%2Fcdancy%2Fjava-libraries)
+* Download a sample settings.xml file that has configured profile to pull from the correct maven repository using this link: [settings.xml](https://bintray.com/repo/downloadMavenRepoSettingsFile/downloadSettings?repoPath=%2Fcdancy%2Fjava-libraries)
 
-2. Add the following repository to the project pom.xml file under project tag:
+**OR**
+
+* Add the following repository to the project pom.xml file under project tag:
 ```
     <repositories>
       <repository>

--- a/README.md
+++ b/README.md
@@ -39,8 +39,6 @@ Can be sourced from jcenter like so:
       <classifier>sources|tests|javadoc|all</classifier> (Optional)
     </dependency>
 	
-**Note**: You need to have bintray maven repository configured to be able to pull bitbucket-rest dependency.
-
 ### Maven repository Configuration:
 
 * Download a sample settings.xml file that has configured profile to pull from the correct maven repository using this link: [settings.xml](https://bintray.com/repo/downloadMavenRepoSettingsFile/downloadSettings?repoPath=%2Fcdancy%2Fjava-libraries)

--- a/README.md
+++ b/README.md
@@ -39,6 +39,25 @@ Can be sourced from jcenter like so:
       <classifier>sources|tests|javadoc|all</classifier> (Optional)
     </dependency>
 	
+**Note**: You need to have bintray maven repository configured to be able to pull bitbucket-rest dependency.
+
+### Maven repository Configuration:
+
+1. You can download a sample settings.xml file that has configured profile to pull from the correct maven repository using this link: [settings.xml](https://bintray.com/repo/downloadMavenRepoSettingsFile/downloadSettings?repoPath=%2Fcdancy%2Fjava-libraries)
+
+2. Add the following repository to the project pom.xml file under project tag:
+```
+    <repositories>
+      <repository>
+        <snapshots>
+          <enabled>false</enabled>
+        </snapshots>
+        <id>bintray-cdancy-java-libraries</id>
+        <name>bintray</name>
+        <url>https://dl.bintray.com/cdancy/java-libraries</url>
+      </repository>
+    </repositories>
+```
 ## Documentation
 
 javadocs can be found via [github pages here](http://cdancy.github.io/bitbucket-rest/docs/javadoc/)


### PR DESCRIPTION
**This PR is based on issue :** [MVN Repository files not found #201 ](https://github.com/cdancy/bitbucket-rest/issues/201)
The PR is adding to the steps of adding bitbucket-rest as a dependency to your maven project and providing 2 different ways to include bintray repo either in settings.xml or within your project pom.xml.
