### PR TITLE
use correct data formats in InsightReportData value

### DIFF
--- a/src/main/java/com/cdancy/bitbucket/rest/domain/insights/InsightReportData.java
+++ b/src/main/java/com/cdancy/bitbucket/rest/domain/insights/InsightReportData.java
@@ -20,6 +20,11 @@ package com.cdancy.bitbucket.rest.domain.insights;
 import com.google.auto.value.AutoValue;
 import org.jclouds.json.SerializedNames;
 
+import java.time.Duration;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+
 @AutoValue
 public abstract class InsightReportData {
     public enum DataType {
@@ -36,12 +41,60 @@ public abstract class InsightReportData {
 
     public abstract DataType type();
 
-    public abstract String value();
+    public abstract Object value();
 
     @SerializedNames({"title", "type", "value"})
-    public static InsightReportData create(final String title,
-                                           final InsightReportData.DataType type,
-                                           final String value) {
+    private static InsightReportData create(final String title,
+            final DataType type,
+            final Object value) {
         return new AutoValue_InsightReportData(title, type, value);
+    }
+
+    public static InsightReportData createBoolean(final String title, final boolean value) {
+        return create(title, DataType.BOOLEAN, value);
+    }
+
+    public static InsightReportData createDate(final String title, final LocalDate value) {
+        return createDate(title, value.atStartOfDay());
+    }
+
+    public static InsightReportData createDate(final String title, final LocalDateTime value) {
+        final long epochMilli = value.atZone(ZoneId.systemDefault()).toInstant().toEpochMilli();
+        return createDate(title, epochMilli);
+    }
+
+    public static InsightReportData createDate(final String title, final long epochMilli) {
+        return create(title, DataType.DATE, epochMilli);
+    }
+
+    public static InsightReportData createDuration(final String title, final Duration duration) {
+        return create(title, DataType.DURATION, duration.toMillis());
+    }
+
+    public static InsightReportData createDuration(final String title, final long millis) {
+        return create(title, DataType.DURATION, millis);
+    }
+
+    public static InsightReportData createLink(final String title, final String href) {
+        return createLink(title, href, href);
+    }
+
+    public static InsightReportData createLink(final String title,
+            final String href,
+            final String linkText) {
+        final InsightReportDataLink link = InsightReportDataLink.create(linkText, href);
+        return create(title, DataType.LINK, link);
+    }
+
+    public static InsightReportData createNumber(final String title, final long number) {
+        return create(title, DataType.NUMBER, number);
+    }
+
+    public static InsightReportData createPercentage(final String title, final byte percentage) {
+        return create(title, DataType.PERCENTAGE, percentage);
+    }
+
+    public static InsightReportData createText(final String title, final String text) {
+        return create(title, DataType.TEXT, text);
     }
 }

--- a/src/main/java/com/cdancy/bitbucket/rest/domain/insights/InsightReportDataLink.java
+++ b/src/main/java/com/cdancy/bitbucket/rest/domain/insights/InsightReportDataLink.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.cdancy.bitbucket.rest.domain.insights;
+
+import com.google.auto.value.AutoValue;
+import org.jclouds.json.SerializedNames;
+
+@AutoValue
+public abstract class InsightReportDataLink {
+    public abstract String linkText();
+
+    public abstract String href();
+
+    @SerializedNames({ "linktext", "href" })
+    public static InsightReportDataLink create(final String linkText, final String href) {
+        return new AutoValue_InsightReportDataLink(linkText, href);
+    }
+}

--- a/src/test/java/com/cdancy/bitbucket/rest/features/InsightsApiLiveTest.java
+++ b/src/test/java/com/cdancy/bitbucket/rest/features/InsightsApiLiveTest.java
@@ -33,6 +33,9 @@ import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
+import java.time.Duration;
+import java.time.LocalDate;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
@@ -64,17 +67,29 @@ public class InsightsApiLiveTest extends BaseBitbucketApiLiveTest {
         commitHash = branch.latestCommit();
 
         final String linkFormat = "https://%s";
+        final List<InsightReportData> data = Arrays.asList(InsightReportData.createBoolean(TestUtilities.randomStringLettersOnly(),
+                                                                                           true),
+                                                           InsightReportData.createDate(TestUtilities.randomStringLettersOnly(),
+                                                                                        LocalDate.of(2019, 12, 18)),
+                                                           InsightReportData.createDuration(TestUtilities.randomStringLettersOnly(),
+                                                                                            Duration.ofSeconds(25)),
+                                                           InsightReportData.createLink(TestUtilities.randomStringLettersOnly(),
+                                                                                        String.format(linkFormat, TestUtilities.randomString()),
+                                                                                        TestUtilities.randomString()),
+                                                           InsightReportData.createNumber(TestUtilities.randomStringLettersOnly(),
+                                                                                          54321),
+                                                           InsightReportData.createPercentage(TestUtilities.randomStringLettersOnly(),
+                                                                                              (byte) 42),
+                                                           InsightReportData.createText(TestUtilities.randomStringLettersOnly(),
+                                                                                        TestUtilities.randomString())
+        );
         createInsightReport = CreateInsightReport.create(TestUtilities.randomString(),
                                                          String.format(linkFormat, TestUtilities.randomString()),
                                                          String.format(linkFormat, TestUtilities.randomString()),
                                                          CreateInsightReport.RESULT.PASS,
                                                          TestUtilities.randomStringLettersOnly(),
                                                          TestUtilities.randomString(),
-                                                         Collections.singletonList(
-                                                             InsightReportData.create(TestUtilities.randomStringLettersOnly(),
-                                                                                      InsightReportData.DataType.TEXT,
-                                                                                      TestUtilities.randomString())
-                                                         ));
+                                                         data);
 
         annotationId = TestUtilities.randomStringLettersOnly();
         createAnnotations = CreateAnnotations.create(Collections.singletonList(

--- a/src/test/java/com/cdancy/bitbucket/rest/features/InsightsApiMockTest.java
+++ b/src/test/java/com/cdancy/bitbucket/rest/features/InsightsApiMockTest.java
@@ -167,7 +167,7 @@ public class InsightsApiMockTest extends BaseBitbucketMockTest {
         try {
 
             final String reportKey = qwertyKeyword;
-            final InsightReportData reportData = InsightReportData.create("Code Coverage", InsightReportData.DataType.PERCENTAGE, "15");
+            final InsightReportData reportData = InsightReportData.createPercentage("Code Coverage", (byte) 15);
             final CreateInsightReport createInsightReport = CreateInsightReport.create("details",
                                                                                        "http://example.com",
                                                                                        "http://example.com/logourl",


### PR DESCRIPTION
Adding Code Insight ReportData of DataTypes other than TEXT should now work

closes #208 

During live testing I got a few `*** Please tell me who you are.` messages, and I don't know how to fix these.
So the live tests could be broken.
