### PR TITLE
Changed parameter name of query parameter "at" to "branchOrTag"

### DIFF
--- a/src/main/java/com/cdancy/bitbucket/rest/features/FileApi.java
+++ b/src/main/java/com/cdancy/bitbucket/rest/features/FileApi.java
@@ -59,8 +59,8 @@ public interface FileApi {
     RawContent raw(@PathParam("project") String project,
                 @PathParam("repo") String repo,
                 @PathParam("filePath") String filePath,
-                @Nullable @QueryParam("at") String commitHash);
-    
+                @Nullable @QueryParam("at") String branchOrTag);
+
     @Named("file:list-lines")
     @Documentation({"https://developer.atlassian.com/static/rest/bitbucket-server/5.1.0/bitbucket-rest.html#idm45588158357840"})
     @Produces(MediaType.APPLICATION_JSON)
@@ -71,7 +71,7 @@ public interface FileApi {
     LinePage listLines(@PathParam("project") String project,
                            @PathParam("repo") String repo,
                            @PathParam("filePath") String filePath,
-                           @Nullable @QueryParam("at") String commitHash,
+                           @Nullable @QueryParam("at") String branchOrTag,
                            @Nullable @QueryParam("type") Boolean type,
                            @Nullable @QueryParam("blame") Boolean blame,
                            @Nullable @QueryParam("noContent") Boolean noContent,
@@ -104,7 +104,7 @@ public interface FileApi {
     FilesPage listFiles(@PathParam("project") String project,
                            @PathParam("repo") String repo,
                            @Nullable @PathParam("path") String path,
-                           @Nullable @QueryParam("at") String commitIdOrRef,
+                           @Nullable @QueryParam("at") String branchOrTag,
                            @Nullable @QueryParam("start") Integer start,
                            @Nullable @QueryParam("limit") Integer limit);
 
@@ -119,5 +119,5 @@ public interface FileApi {
     LastModified lastModified(@PathParam("project") String project,
             @PathParam("repo") String repo,
             @Nullable @PathParam("path") String path,
-            @QueryParam("at") String commitIdOrRef);
+            @QueryParam("at") String branchOrTag);
 }

--- a/src/main/java/com/cdancy/bitbucket/rest/features/PullRequestApi.java
+++ b/src/main/java/com/cdancy/bitbucket/rest/features/PullRequestApi.java
@@ -87,7 +87,7 @@ public interface PullRequestApi {
     PullRequestPage list(@PathParam("project") String project,
                     @PathParam("repo") String repo,
                     @Nullable @QueryParam("direction") String direction,
-                    @Nullable @QueryParam("at") String at,
+                    @Nullable @QueryParam("at") String branchOrTag,
                     @Nullable @QueryParam("state") String state,
                     @Nullable @QueryParam("order") String order,
                     @Nullable @QueryParam("withAttributes") Boolean withAttributes,

--- a/src/main/java/com/cdancy/bitbucket/rest/features/SyncApi.java
+++ b/src/main/java/com/cdancy/bitbucket/rest/features/SyncApi.java
@@ -66,7 +66,7 @@ public interface SyncApi {
     @GET
     SyncStatus status(@PathParam("project") String project,
                       @PathParam("repo") String repo,
-                      @Nullable @QueryParam("at") String at);
+                      @Nullable @QueryParam("at") String branchOrTag);
 
     @Named("sync:synchronize")
     @Documentation({"https://docs.atlassian.com/DAC/rest/stash/3.7.2/stash-repository-ref-sync-rest.html"})


### PR DESCRIPTION
In the FileApi, there is the function listLines, which gives plenty of parameters.
One of the parameters based on the Bitbucket documentation is "at", in your project it's "commitHash".

Unfortunately this is very confusing, as it is not referencing to a specific commit hash, but to a branch e.g.

So calling the API with `?at=refs/heads/master` or `?at=refs/tags/%myTag%` will give a valid result.
Putting a commitHash instead would produce an error message:
````
{
    "errors": [
        {
            "context": null,
            "exceptionName": "com.atlassian.bitbucket.content.NoSuchPathException",
            "message": "The path \"xxx\" does not exist at revision \"9aa913957f1...\""
        }
    ]
}
````

### Expected Behavior
To avoid misunderstanding, the parameter should be named like in Bitbucket documentation as there is at least some documentation there

### Current Behavior
The parameter `commitHash` is named wrongly and should be renamed

### Context
It is just annoying and misleading if you deal with that

### Your Environment
Version of bitbucket-rest: 2.6.3
Version of Bitbucket: 7.4.0

----

As `at` is not very saying imho and `commitHash` or `commitIdOrRef` are wrong, I would suggest to change it to `branchOrTag`.

Closes #230 