### PR TITLE
Adding labels api support

### DIFF
--- a/src/main/java/com/cdancy/bitbucket/rest/BitbucketApi.java
+++ b/src/main/java/com/cdancy/bitbucket/rest/BitbucketApi.java
@@ -28,6 +28,7 @@ import com.cdancy.bitbucket.rest.features.DefaultReviewersApi;
 import com.cdancy.bitbucket.rest.features.FileApi;
 import com.cdancy.bitbucket.rest.features.HookApi;
 import com.cdancy.bitbucket.rest.features.InsightsApi;
+import com.cdancy.bitbucket.rest.features.LabelsApi;
 import com.cdancy.bitbucket.rest.features.ProjectApi;
 import com.cdancy.bitbucket.rest.features.PullRequestApi;
 import com.cdancy.bitbucket.rest.features.RepositoryApi;
@@ -95,8 +96,10 @@ public interface BitbucketApi extends Closeable {
 
     @Delegate
     KeysApi keysApi();
-    
+
     @Delegate
     SearchApi searchApi();
 
+    @Delegate
+    LabelsApi labelsApi();
 }

--- a/src/main/java/com/cdancy/bitbucket/rest/domain/labels/Labels.java
+++ b/src/main/java/com/cdancy/bitbucket/rest/domain/labels/Labels.java
@@ -1,0 +1,23 @@
+package com.cdancy.bitbucket.rest.domain.labels;
+
+import com.cdancy.bitbucket.rest.BitbucketUtils;
+import com.cdancy.bitbucket.rest.domain.common.Error;
+import com.cdancy.bitbucket.rest.domain.common.ErrorsHolder;
+import com.google.auto.value.AutoValue;
+import org.jclouds.json.SerializedNames;
+
+import java.util.List;
+
+@AutoValue
+public abstract class Labels implements ErrorsHolder {
+
+    public abstract String name();
+
+    Labels() {
+    }
+
+    @SerializedNames({"name", "errors"})
+    public static Labels create(final String name, final List<Error> errors) {
+        return new AutoValue_Labels(BitbucketUtils.nullToEmpty(errors), name);
+    }
+}

--- a/src/main/java/com/cdancy/bitbucket/rest/domain/labels/Labels.java
+++ b/src/main/java/com/cdancy/bitbucket/rest/domain/labels/Labels.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.cdancy.bitbucket.rest.domain.labels;
 
 import com.cdancy.bitbucket.rest.BitbucketUtils;

--- a/src/main/java/com/cdancy/bitbucket/rest/domain/labels/LabelsPage.java
+++ b/src/main/java/com/cdancy/bitbucket/rest/domain/labels/LabelsPage.java
@@ -1,0 +1,34 @@
+package com.cdancy.bitbucket.rest.domain.labels;
+
+import com.cdancy.bitbucket.rest.BitbucketUtils;
+import com.cdancy.bitbucket.rest.domain.common.Error;
+import com.cdancy.bitbucket.rest.domain.common.ErrorsHolder;
+import com.cdancy.bitbucket.rest.domain.common.Page;
+import com.google.auto.value.AutoValue;
+import org.jclouds.javax.annotation.Nullable;
+import org.jclouds.json.SerializedNames;
+
+import java.util.List;
+
+@AutoValue
+public abstract class LabelsPage implements Page<Labels>, ErrorsHolder {
+
+    @SerializedNames({"start", "limit", "size", "nextPageStart",
+        "isLastPage", "values", "errors"})
+    public static LabelsPage create(final int start,
+                                    final int limit,
+                                    final int size,
+                                    final int nextPageStart,
+                                    final boolean isLastPage,
+                                    final List<Labels> values,
+                                    @Nullable final List<Error> errors) {
+
+        return new AutoValue_LabelsPage(start,
+            limit,
+            size,
+            nextPageStart,
+            isLastPage,
+            BitbucketUtils.nullToEmpty(values),
+            BitbucketUtils.nullToEmpty(errors));
+    }
+}

--- a/src/main/java/com/cdancy/bitbucket/rest/domain/labels/LabelsPage.java
+++ b/src/main/java/com/cdancy/bitbucket/rest/domain/labels/LabelsPage.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.cdancy.bitbucket.rest.domain.labels;
 
 import com.cdancy.bitbucket.rest.BitbucketUtils;
@@ -13,8 +30,7 @@ import java.util.List;
 @AutoValue
 public abstract class LabelsPage implements Page<Labels>, ErrorsHolder {
 
-    @SerializedNames({"start", "limit", "size", "nextPageStart",
-        "isLastPage", "values", "errors"})
+    @SerializedNames({"start", "limit", "size", "nextPageStart", "isLastPage", "values", "errors"})
     public static LabelsPage create(final int start,
                                     final int limit,
                                     final int size,

--- a/src/main/java/com/cdancy/bitbucket/rest/fallbacks/BitbucketFallbacks.java
+++ b/src/main/java/com/cdancy/bitbucket/rest/fallbacks/BitbucketFallbacks.java
@@ -590,7 +590,7 @@ public final class BitbucketFallbacks {
 
     public static final class LabelsOnError implements Fallback<Object> {
         @Override
-        public Object createOrPropagate(Throwable throwable) throws Exception {
+        public Object createOrPropagate(final Throwable throwable) throws Exception {
             if (checkNotNull(throwable, "throwable") != null) {
                 return createLabelsPageFromErrors(getErrors(throwable.getMessage()));
             }

--- a/src/main/java/com/cdancy/bitbucket/rest/fallbacks/BitbucketFallbacks.java
+++ b/src/main/java/com/cdancy/bitbucket/rest/fallbacks/BitbucketFallbacks.java
@@ -47,6 +47,7 @@ import com.cdancy.bitbucket.rest.domain.file.RawContent;
 import com.cdancy.bitbucket.rest.domain.insights.AnnotationsResponse;
 import com.cdancy.bitbucket.rest.domain.insights.InsightReport;
 import com.cdancy.bitbucket.rest.domain.insights.InsightReportPage;
+import com.cdancy.bitbucket.rest.domain.labels.LabelsPage;
 import com.cdancy.bitbucket.rest.domain.participants.Participants;
 import com.cdancy.bitbucket.rest.domain.participants.Participants.Role;
 import com.cdancy.bitbucket.rest.domain.participants.Participants.Status;
@@ -587,6 +588,16 @@ public final class BitbucketFallbacks {
         }
     }
 
+    public static final class LabelsOnError implements Fallback<Object> {
+        @Override
+        public Object createOrPropagate(Throwable throwable) throws Exception {
+            if (checkNotNull(throwable, "throwable") != null) {
+                return createLabelsPageFromErrors(getErrors(throwable.getMessage()));
+            }
+            throw propagate(throwable);
+        }
+    }
+
     public static RequestStatus createRequestStatusFromErrors(final List<Error> errors) {
         return RequestStatus.create(false, errors);
     }
@@ -776,6 +787,10 @@ public final class BitbucketFallbacks {
 
     public static AccessKeyPage createAccessKeyPageFromErrors(final List<Error> errors) {
         return AccessKeyPage.create(0, 0, 0, 0, false, null, errors);
+    }
+
+    public static LabelsPage createLabelsPageFromErrors(final List<Error> errors) {
+        return LabelsPage.create(0, 0, 0, 0, false, null, errors);
     }
 
     /**

--- a/src/main/java/com/cdancy/bitbucket/rest/features/LabelsApi.java
+++ b/src/main/java/com/cdancy/bitbucket/rest/features/LabelsApi.java
@@ -1,0 +1,31 @@
+package com.cdancy.bitbucket.rest.features;
+
+import com.cdancy.bitbucket.rest.annotations.Documentation;
+import com.cdancy.bitbucket.rest.domain.labels.LabelsPage;
+import com.cdancy.bitbucket.rest.fallbacks.BitbucketFallbacks;
+import com.cdancy.bitbucket.rest.filters.BitbucketAuthenticationFilter;
+import org.jclouds.javax.annotation.Nullable;
+import org.jclouds.rest.annotations.Fallback;
+import org.jclouds.rest.annotations.RequestFilters;
+
+import javax.inject.Named;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.MediaType;
+
+@Produces(MediaType.APPLICATION_JSON)
+@RequestFilters(BitbucketAuthenticationFilter.class)
+@Path("/rest")
+public interface LabelsApi {
+
+    @Named("labels:list")
+    @Documentation({"https://docs.atlassian.com/bitbucket-server/rest/6.0.0/bitbucket-rest.html#idp86"})
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Path("/api/{jclouds.api-version}/labels")
+    @Fallback(BitbucketFallbacks.LabelsOnError.class)
+    @GET
+    LabelsPage list(@Nullable @QueryParam("prefix") String prefix);
+}

--- a/src/main/java/com/cdancy/bitbucket/rest/features/LabelsApi.java
+++ b/src/main/java/com/cdancy/bitbucket/rest/features/LabelsApi.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.cdancy.bitbucket.rest.features;
 
 import com.cdancy.bitbucket.rest.annotations.Documentation;

--- a/src/test/java/com/cdancy/bitbucket/rest/features/LabelsApiLiveTest.java
+++ b/src/test/java/com/cdancy/bitbucket/rest/features/LabelsApiLiveTest.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.cdancy.bitbucket.rest.features;
 
 import com.cdancy.bitbucket.rest.BaseBitbucketApiLiveTest;

--- a/src/test/java/com/cdancy/bitbucket/rest/features/LabelsApiLiveTest.java
+++ b/src/test/java/com/cdancy/bitbucket/rest/features/LabelsApiLiveTest.java
@@ -1,0 +1,19 @@
+package com.cdancy.bitbucket.rest.features;
+
+import com.cdancy.bitbucket.rest.BaseBitbucketApiLiveTest;
+import org.testng.annotations.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Test(groups = "live", testName = "LabelsApiLiveTest", singleThreaded = true)
+public class LabelsApiLiveTest extends BaseBitbucketApiLiveTest {
+
+    @Test
+    public void testLabel() {
+        assertThat(api().list(null).values()).isEmpty();
+    }
+
+    private LabelsApi api() {
+        return api.labelsApi();
+    }
+}

--- a/src/test/java/com/cdancy/bitbucket/rest/features/LabelsApiMockTest.java
+++ b/src/test/java/com/cdancy/bitbucket/rest/features/LabelsApiMockTest.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.cdancy.bitbucket.rest.features;
 
 import com.cdancy.bitbucket.rest.BaseBitbucketMockTest;

--- a/src/test/java/com/cdancy/bitbucket/rest/features/LabelsApiMockTest.java
+++ b/src/test/java/com/cdancy/bitbucket/rest/features/LabelsApiMockTest.java
@@ -1,0 +1,51 @@
+package com.cdancy.bitbucket.rest.features;
+
+import com.cdancy.bitbucket.rest.BaseBitbucketMockTest;
+import com.cdancy.bitbucket.rest.BitbucketApi;
+import com.cdancy.bitbucket.rest.domain.labels.LabelsPage;
+import com.squareup.okhttp.mockwebserver.MockResponse;
+import com.squareup.okhttp.mockwebserver.MockWebServer;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Test(groups = "unit", testName = "LabelsApiMockTest")
+public class LabelsApiMockTest extends BaseBitbucketMockTest {
+
+    public void testListAllLabels() throws IOException {
+        final MockWebServer server = mockWebServer();
+
+        server.enqueue(new MockResponse().setBody(payloadFromResource("/labels-list.json")).setResponseCode(201));
+
+        try (final BitbucketApi baseApi = api(server.url("/").url())) {
+            final LabelsPage labelsPage = baseApi.labelsApi().list(null);
+            assertThat(labelsPage).isNotNull();
+            assertThat(labelsPage.errors().isEmpty()).isTrue();
+            assertThat(labelsPage.values().size() > 0).isTrue();
+
+            assertThat(labelsPage.values().get(0).name()).isEqualTo("labelName");
+
+        } finally {
+            server.shutdown();
+        }
+    }
+
+    public void testListAllLabelError() throws IOException {
+        final MockWebServer server = mockWebServer();
+
+        server.enqueue(new MockResponse().setBody(payloadFromResource("/errors.json")).setResponseCode(401));
+
+        try (final BitbucketApi baseApi = api(server.url("/").url())) {
+            final LabelsPage labelsPage = baseApi.labelsApi().list(null);
+            assertThat(labelsPage).isNotNull();
+            assertThat(labelsPage.values().size() > 0).isFalse();
+
+            assertThat(labelsPage.errors()).hasSizeGreaterThan(0);
+
+        } finally {
+            server.shutdown();
+        }
+    }
+}

--- a/src/test/resources/labels-list.json
+++ b/src/test/resources/labels-list.json
@@ -1,0 +1,11 @@
+{
+  "size": 1,
+  "limit": 25,
+  "isLastPage": true,
+  "values": [
+    {
+      "name": "labelName"
+    }
+  ],
+  "start": 0
+}


### PR DESCRIPTION
PR for #182 
Adding support to `/rest/api/1.0/labels` API endpoint in https://docs.atlassian.com/bitbucket-server/rest/6.0.0/bitbucket-rest.html#idp86