### PR TITLE
Use user.name() instead of user.slug() to avoid case issues

### DIFF
--- a/src/test/java/com/cdancy/bitbucket/rest/TestUtilities.java
+++ b/src/test/java/com/cdancy/bitbucket/rest/TestUtilities.java
@@ -79,7 +79,7 @@ public class TestUtilities extends BitbucketUtils {
                 assertThat(userPage).isNotNull();
                 assertThat(userPage.size() > 0).isTrue();
                 for (final User user : userPage.values()) {
-                    if (username.equals(user.slug())) {
+                    if (username.equals(user.name())) {
                         defaultUser = user;
                         break;
                     }


### PR DESCRIPTION
closes #253 

This change makes the username comparison in TestUtilities consistent with how the username is presented when getting it from authentication info (`auth.authValue()`). Using `user.slug()` means the username is all lower case causing integ tests to fail if the user had put in a username like `JoeSmith` because the comparison ends up being on `joesmith != JoeSmith`. 

By using `user.name()` we get back the same name (in terms of case) as it seems to be stored in the auth info `auth.authValue()`. Login does not appear to be case sensitive though - so an alternative approach is just to normalise all username strings to lowercase and compare that.
