### PR TITLE
260: Add committer & committerTimestamp to Commit object

### DIFF
--- a/src/main/java/com/cdancy/bitbucket/rest/domain/commit/Commit.java
+++ b/src/main/java/com/cdancy/bitbucket/rest/domain/commit/Commit.java
@@ -42,6 +42,11 @@ public abstract class Commit implements ErrorsHolder {
     public abstract long authorTimestamp();
 
     @Nullable
+    public abstract Author committer();
+
+    public abstract long committerTimestamp();
+
+    @Nullable
     public abstract String message();
 
     public abstract List<Parents> parents();
@@ -49,22 +54,26 @@ public abstract class Commit implements ErrorsHolder {
     Commit() {
     }
 
-    @SerializedNames({ "id", "displayId", "author", 
-            "authorTimestamp", "message", "parents", "errors" })
-    public static Commit create(final String id, 
-            final String displayId, 
+    @SerializedNames({ "id", "displayId", "author",
+            "authorTimestamp", "committer", "committerTimestamp", "message", "parents", "errors" })
+    public static Commit create(final String id,
+            final String displayId,
             final Author author,
-            final long authorTimestamp, 
-            final String message, 
-            final List<Parents> parents, 
+            final long authorTimestamp,
+            final Author committer,
+            final long committerTimestamp,
+            final String message,
+            final List<Parents> parents,
             final List<Error> errors) {
-        
-        return new AutoValue_Commit(BitbucketUtils.nullToEmpty(errors), 
-                id, 
-                displayId, 
-                author, 
-                authorTimestamp, 
-                message, 
+
+        return new AutoValue_Commit(BitbucketUtils.nullToEmpty(errors),
+                id,
+                displayId,
+                author,
+                authorTimestamp,
+                committer,
+                committerTimestamp,
+                message,
                 BitbucketUtils.nullToEmpty(parents));
     }
 }

--- a/src/main/java/com/cdancy/bitbucket/rest/fallbacks/BitbucketFallbacks.java
+++ b/src/main/java/com/cdancy/bitbucket/rest/fallbacks/BitbucketFallbacks.java
@@ -682,7 +682,7 @@ public final class BitbucketFallbacks {
     }
 
     public static Commit createCommitFromErrors(final List<Error> errors) {
-        return Commit.create("-1", "-1", null, 0, null, null, errors);
+        return Commit.create("-1", "-1", null, 0, null, 0, null, null, errors);
     }
 
     public static Tag createTagFromErrors(final List<Error> errors) {

--- a/src/test/java/com/cdancy/bitbucket/rest/features/CommitsApiMockTest.java
+++ b/src/test/java/com/cdancy/bitbucket/rest/features/CommitsApiMockTest.java
@@ -45,7 +45,7 @@ public class CommitsApiMockTest extends BaseBitbucketMockTest {
     private final String getMethod = "GET";
     private final String restApiPath = "/rest/api/";
     private final String limitKeyword = "limit";
-    
+
     public void testGetCommit() throws Exception {
         final MockWebServer server = mockWebServer();
 
@@ -56,6 +56,10 @@ public class CommitsApiMockTest extends BaseBitbucketMockTest {
             assertThat(commit).isNotNull();
             assertThat(commit.errors().isEmpty()).isTrue();
             assertThat(commit.id().equalsIgnoreCase(commitHash)).isTrue();
+            assertThat(commit.authorTimestamp()).isNotNull().isNotEqualTo(0);
+            assertThat(commit.author()).isNotNull();
+            assertThat(commit.committerTimestamp()).isNotNull().isNotEqualTo(0);
+            assertThat(commit.committer()).isNotNull();
 
             assertSent(server, getMethod, restBasePath + BitbucketApiMetadata.API_VERSION
                     + "/projects/" + projectKey + "/repos/" + repoKey + "/commits/" + commitHash);
@@ -121,7 +125,7 @@ public class CommitsApiMockTest extends BaseBitbucketMockTest {
             server.shutdown();
         }
     }
-    
+
     public void testListCommits() throws Exception {
         final MockWebServer server = mockWebServer();
 

--- a/src/test/resources/commit.json
+++ b/src/test/resources/commit.json
@@ -3,10 +3,17 @@
     "displayId": "abcdef0123a",
     "author": {
         "name": "charlie",
-        "emailAddress": "charlie@example.com"
+        "emailAddress": "charlie@example.com",
+        "displayName": "Charlie Brown"
     },
     "authorTimestamp": 1484800877151,
     "message": "WIP on feature 1",
+    "committer": {
+        "name": "john",
+        "emailAddress": "john@example.com",
+        "displayName": "John Smith"
+    },
+    "committerTimestamp": 1594900977151,
     "parents": [
         {
             "id": "abcdef0123abcdef4567abcdef8987abcdef6543",


### PR DESCRIPTION
Allows committer & commiterTimestamp information from a commit to be retrieved with the CommitApi.

Closes #260
