### PR TITLE
Pr settings unapprove on update

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 group = com.cdancy
-version = 2.7.2-SNAPSHOT
+version = 2.7.2-unapproveOnUpdate-SNAPSHOT
 
 artifactoryURL = http://127.0.0.1:8080/artifactory
 artifactoryUser = admin

--- a/src/main/java/com/cdancy/bitbucket/rest/domain/repository/PullRequestSettings.java
+++ b/src/main/java/com/cdancy/bitbucket/rest/domain/repository/PullRequestSettings.java
@@ -44,21 +44,26 @@ public abstract class PullRequestSettings implements ErrorsHolder {
     @Nullable
     public abstract Long requiredSuccessfulBuilds();
 
-    @SerializedNames({ "mergeConfig", "requiredAllApprovers", 
+    @Nullable
+    public abstract Boolean unapproveOnUpdate();
+
+    @SerializedNames({ "mergeConfig", "requiredAllApprovers",
             "requiredAllTasksComplete", "requiredApprovers",
-            "requiredSuccessfulBuilds", "errors" })
-    public static PullRequestSettings create(final MergeConfig mergeConfig, 
+            "requiredSuccessfulBuilds", "unapproveOnUpdate", "errors" })
+    public static PullRequestSettings create(final MergeConfig mergeConfig,
             final Boolean requiredAllApprovers,
-            final Boolean requiredAllTasksComplete, 
+            final Boolean requiredAllTasksComplete,
             final Long requiredApprovers,
-            final Long requiredSuccessfulBuilds, 
+            final Long requiredSuccessfulBuilds,
+            final Boolean unapproveOnUpdate,
             @Nullable final List<Error> errors) {
-        
-        return new AutoValue_PullRequestSettings(BitbucketUtils.nullToEmpty(errors), 
-                mergeConfig, 
+
+        return new AutoValue_PullRequestSettings(BitbucketUtils.nullToEmpty(errors),
+                mergeConfig,
                 requiredAllApprovers,
-                requiredAllTasksComplete, 
-                requiredApprovers, 
-                requiredSuccessfulBuilds);
+                requiredAllTasksComplete,
+                requiredApprovers,
+                requiredSuccessfulBuilds,
+                unapproveOnUpdate);
     }
 }

--- a/src/main/java/com/cdancy/bitbucket/rest/fallbacks/BitbucketFallbacks.java
+++ b/src/main/java/com/cdancy/bitbucket/rest/fallbacks/BitbucketFallbacks.java
@@ -738,7 +738,7 @@ public final class BitbucketFallbacks {
     }
 
     public static PullRequestSettings createPullRequestSettingsFromErrors(final List<Error> errors) {
-        return PullRequestSettings.create(null, null, null, null, null, errors);
+        return PullRequestSettings.create(null, null, null, null, null, null, errors);
     }
 
     public static ProjectPage createProjectPageFromErrors(final List<Error> errors) {

--- a/src/main/java/com/cdancy/bitbucket/rest/options/CreatePullRequestSettings.java
+++ b/src/main/java/com/cdancy/bitbucket/rest/options/CreatePullRequestSettings.java
@@ -45,7 +45,7 @@ public abstract class CreatePullRequestSettings {
     }
 
     @SerializedNames({ "mergeConfig", "requiredAllApprovers", "requiredAllTasksComplete",
-            "requiredApprovers", "requiredSuccessfulBuilds" })
+            "requiredApprovers", "requiredSuccessfulBuilds", "unapproveOnUpdate" })
     public static CreatePullRequestSettings create(final MergeConfig mergeConfig,
             final boolean requiredAllApprovers,
             final boolean requiredAllTasksComplete,

--- a/src/main/java/com/cdancy/bitbucket/rest/options/CreatePullRequestSettings.java
+++ b/src/main/java/com/cdancy/bitbucket/rest/options/CreatePullRequestSettings.java
@@ -35,20 +35,24 @@ public abstract class CreatePullRequestSettings {
 
     public abstract long requiredSuccessfulBuilds();
 
+    public abstract boolean unapproveOnUpdate();
+
     public static CreatePullRequestSettings create(final PullRequestSettings pullRequestSettings) {
         return new AutoValue_CreatePullRequestSettings(pullRequestSettings.mergeConfig(),
             pullRequestSettings.requiredAllApprovers(), pullRequestSettings.requiredAllTasksComplete(),
-            pullRequestSettings.requiredApprovers(), pullRequestSettings.requiredSuccessfulBuilds());
+            pullRequestSettings.requiredApprovers(), pullRequestSettings.requiredSuccessfulBuilds(),
+            pullRequestSettings.unapproveOnUpdate());
     }
 
     @SerializedNames({ "mergeConfig", "requiredAllApprovers", "requiredAllTasksComplete",
             "requiredApprovers", "requiredSuccessfulBuilds" })
-    public static CreatePullRequestSettings create(final MergeConfig mergeConfig, 
+    public static CreatePullRequestSettings create(final MergeConfig mergeConfig,
             final boolean requiredAllApprovers,
-            final boolean requiredAllTasksComplete, 
+            final boolean requiredAllTasksComplete,
             final long requiredApprovers,
-            final long requiredSuccessfulBuilds) {
+            final long requiredSuccessfulBuilds,
+            final boolean unapproveOnUpdate) {
         return new AutoValue_CreatePullRequestSettings(mergeConfig, requiredAllApprovers, requiredAllTasksComplete,
-            requiredApprovers, requiredSuccessfulBuilds);
+            requiredApprovers, requiredSuccessfulBuilds, unapproveOnUpdate);
     }
 }

--- a/src/test/java/com/cdancy/bitbucket/rest/features/RepositoryApiLiveTest.java
+++ b/src/test/java/com/cdancy/bitbucket/rest/features/RepositoryApiLiveTest.java
@@ -210,7 +210,7 @@ public class RepositoryApiLiveTest extends BaseBitbucketApiLiveTest {
         final List<MergeStrategy> listStrategy = new ArrayList<>();
         listStrategy.add(strategy);
         final MergeConfig mergeConfig = MergeConfig.create(strategy, listStrategy, MergeConfig.MergeConfigType.REPOSITORY);
-        final CreatePullRequestSettings pullRequestSettings = CreatePullRequestSettings.create(mergeConfig, false, false, 0, 1);
+        final CreatePullRequestSettings pullRequestSettings = CreatePullRequestSettings.create(mergeConfig, false, false, 0, 1, true);
 
         final PullRequestSettings settings = api().updatePullRequestSettings(projectKey, repoKey, pullRequestSettings);
         assertThat(settings).isNotNull();

--- a/src/test/java/com/cdancy/bitbucket/rest/features/RepositoryApiMockTest.java
+++ b/src/test/java/com/cdancy/bitbucket/rest/features/RepositoryApiMockTest.java
@@ -501,6 +501,7 @@ public class RepositoryApiMockTest extends BaseBitbucketMockTest {
             assertThat(settings.errors()).isEmpty();
             assertThat(settings.requiredAllApprovers()).isFalse();
             assertThat(settings.requiredAllTasksComplete()).isTrue();
+            assertThat(settings.unapproveOnUpdate()).isTrue();
             assertSent(server, getMethod, restApiPath + BitbucketApiMetadata.API_VERSION
                     + projectsPath + projectKey + reposPath + repoKey + pullRequestsPath);
         } finally {
@@ -629,7 +630,7 @@ public class RepositoryApiMockTest extends BaseBitbucketMockTest {
             final List<MergeStrategy> listStrategy = new ArrayList<>();
             listStrategy.add(strategy);
             final MergeConfig mergeConfig = MergeConfig.create(strategy, listStrategy, MergeConfig.MergeConfigType.REPOSITORY);
-            final CreatePullRequestSettings pullRequestSettings = CreatePullRequestSettings.create(mergeConfig, false, false, 0, 1);
+            final CreatePullRequestSettings pullRequestSettings = CreatePullRequestSettings.create(mergeConfig, false, false, 0, 1, true);
             final PullRequestSettings settings = api.updatePullRequestSettings(projectKey, repoKey, pullRequestSettings);
 
             assertThat(settings).isNotNull();
@@ -676,7 +677,7 @@ public class RepositoryApiMockTest extends BaseBitbucketMockTest {
             final List<MergeStrategy> listStrategy = new ArrayList<>();
             listStrategy.add(strategy);
             final MergeConfig mergeConfig = MergeConfig.create(strategy, listStrategy, MergeConfig.MergeConfigType.REPOSITORY);
-            final CreatePullRequestSettings pullRequestSettings = CreatePullRequestSettings.create(mergeConfig, false, false, 0, 1);
+            final CreatePullRequestSettings pullRequestSettings = CreatePullRequestSettings.create(mergeConfig, false, false, 0, 1, true);
             final PullRequestSettings settings = api.updatePullRequestSettings(projectKey, repoKey, pullRequestSettings);
 
             assertThat(settings).isNotNull();

--- a/src/test/resources/pull-request-settings.json
+++ b/src/test/resources/pull-request-settings.json
@@ -49,5 +49,6 @@
   "requiredAllApprovers": false,
   "requiredAllTasksComplete": true,
   "requiredApprovers": 2,
-  "requiredSuccessfulBuilds": 1
+  "requiredSuccessfulBuilds": 1,
+  "unapproveOnUpdate": true
 }


### PR DESCRIPTION
Adds `unapproveOnUpdate` to `PullRequestSettings` and `CreatePullRequestSettings` in order to support getting and setting that property on repositories' PR settings.

closes #262

Please do not create a Pull Request without first creating an ISSUE.
Any change needs to be discussed before proceeding.
Failure to do so may result in the rejection of the Pull Request.

Explain the **details** for making this change: What existing problem does the Pull Request solve? Why is this feature beneficial?

**On adding new feautes/endpoints**

No more than 1 endpoint should be coded within a Pull Request. 
This alone requires enough code to review and adding more than 1 WILL result in your Pull Request either being ignored or rejected outright.

**On adding Mock and Integ Tests**

At _least_ 2 mock tests and 2 integ tests are required prior to merging. 
Each pair should should test what the success and failure of added change looks like.
More complicated additions will of course require more tests.

**On CI testing (currently using travis)**

Code will not be reviewed until CI passes.
Current CI does NOT exercise `integ` tests and so each Pull Request will have to be run manually by one of the maintainers to confirm it works as expected: please be patient.

**On automtatic closing of ISSUES**

Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
