### PR TITLE
ISSUE-283: Add properties to Commit object

### DIFF
--- a/src/main/java/com/cdancy/bitbucket/rest/domain/commit/Commit.java
+++ b/src/main/java/com/cdancy/bitbucket/rest/domain/commit/Commit.java
@@ -22,7 +22,9 @@ import com.cdancy.bitbucket.rest.domain.common.ErrorsHolder;
 import com.cdancy.bitbucket.rest.domain.pullrequest.Author;
 import com.cdancy.bitbucket.rest.domain.pullrequest.Parents;
 import java.util.List;
+import java.util.Map;
 
+import com.google.gson.JsonElement;
 import org.jclouds.json.SerializedNames;
 
 import com.cdancy.bitbucket.rest.BitbucketUtils;
@@ -49,13 +51,16 @@ public abstract class Commit implements ErrorsHolder {
     @Nullable
     public abstract String message();
 
+    @Nullable
+    public abstract Map<String, JsonElement> properties();
+
     public abstract List<Parents> parents();
 
     Commit() {
     }
 
     @SerializedNames({ "id", "displayId", "author",
-            "authorTimestamp", "committer", "committerTimestamp", "message", "parents", "errors" })
+            "authorTimestamp", "committer", "committerTimestamp", "message", "properties", "parents", "errors" })
     public static Commit create(final String id,
             final String displayId,
             final Author author,
@@ -63,6 +68,7 @@ public abstract class Commit implements ErrorsHolder {
             final Author committer,
             final long committerTimestamp,
             final String message,
+            final Map<String, JsonElement> properties,
             final List<Parents> parents,
             final List<Error> errors) {
 
@@ -74,6 +80,7 @@ public abstract class Commit implements ErrorsHolder {
                 committer,
                 committerTimestamp,
                 message,
+                properties,
                 BitbucketUtils.nullToEmpty(parents));
     }
 }

--- a/src/main/java/com/cdancy/bitbucket/rest/fallbacks/BitbucketFallbacks.java
+++ b/src/main/java/com/cdancy/bitbucket/rest/fallbacks/BitbucketFallbacks.java
@@ -682,7 +682,7 @@ public final class BitbucketFallbacks {
     }
 
     public static Commit createCommitFromErrors(final List<Error> errors) {
-        return Commit.create("-1", "-1", null, 0, null, 0, null, null, errors);
+        return Commit.create("-1", "-1", null, 0, null, 0, null,null, null, errors);
     }
 
     public static Tag createTagFromErrors(final List<Error> errors) {

--- a/src/test/java/com/cdancy/bitbucket/rest/features/CommitsApiMockTest.java
+++ b/src/test/java/com/cdancy/bitbucket/rest/features/CommitsApiMockTest.java
@@ -60,6 +60,7 @@ public class CommitsApiMockTest extends BaseBitbucketMockTest {
             assertThat(commit.author()).isNotNull();
             assertThat(commit.committerTimestamp()).isNotNull().isNotEqualTo(0);
             assertThat(commit.committer()).isNotNull();
+            assertThat(commit.properties()).isNotNull().isNotEqualTo(0);
 
             assertSent(server, getMethod, restBasePath + BitbucketApiMetadata.API_VERSION
                     + "/projects/" + projectKey + "/repos/" + repoKey + "/commits/" + commitHash);

--- a/src/test/resources/commit.json
+++ b/src/test/resources/commit.json
@@ -19,5 +19,10 @@
             "id": "abcdef0123abcdef4567abcdef8987abcdef6543",
             "displayId": "abcdef0"
         }
-    ]
+    ],
+    "properties": {
+        "jira-key": [
+            "IEA-2170"
+        ]
+    }
 }


### PR DESCRIPTION
Allows properties information from a commit to be retrieved with the CommitApi.

Closes #283 