### PR TITLE
Bugfix/project api list

### DIFF
--- a/src/main/java/com/cdancy/bitbucket/rest/features/ProjectApi.java
+++ b/src/main/java/com/cdancy/bitbucket/rest/features/ProjectApi.java
@@ -79,6 +79,7 @@ public interface ProjectApi {
     @Named("/api/{jclouds.api-version}/projects/project:list")
     @Documentation({"https://developer.atlassian.com/static/rest/bitbucket-server/latest/bitbucket-rest.html#idm45888277975392"})
     @Consumes(MediaType.APPLICATION_JSON)
+    @Path("/api/{jclouds.api-version}/projects")
     @Fallback(BitbucketFallbacks.ProjectPageOnError.class)
     @GET
     ProjectPage list(@Nullable @QueryParam("name") String name,

--- a/src/main/java/com/cdancy/bitbucket/rest/features/RepositoryApi.java
+++ b/src/main/java/com/cdancy/bitbucket/rest/features/RepositoryApi.java
@@ -19,6 +19,7 @@ package com.cdancy.bitbucket.rest.features;
 
 import com.cdancy.bitbucket.rest.annotations.Documentation;
 import com.cdancy.bitbucket.rest.domain.common.RequestStatus;
+import com.cdancy.bitbucket.rest.domain.labels.LabelsPage;
 import com.cdancy.bitbucket.rest.domain.repository.PermissionsPage;
 import com.cdancy.bitbucket.rest.domain.repository.PullRequestSettings;
 import com.cdancy.bitbucket.rest.domain.repository.Repository;
@@ -204,4 +205,13 @@ public interface RepositoryApi {
                                          @PathParam("repo") String repo,
                                          @Nullable @QueryParam("start") Integer start,
                                          @Nullable @QueryParam("limit") Integer limit);
+
+    @Named("repository:getLabels")
+    @Documentation({"https://developer.atlassian.com/static/rest/bitbucket-server/latest/bitbucket-rest.html#idp273"})
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Path("/api/{jclouds.api-version}/projects/{project}/repos/{repo}/labels")
+    @Fallback(BitbucketFallbacks.RepositoryOnError.class)
+    @GET
+    LabelsPage getLabels(@PathParam("project") String project,
+                         @PathParam("repo") String repo);
 }

--- a/src/test/java/com/cdancy/bitbucket/rest/features/RepositoryApiMockTest.java
+++ b/src/test/java/com/cdancy/bitbucket/rest/features/RepositoryApiMockTest.java
@@ -20,6 +20,7 @@ package com.cdancy.bitbucket.rest.features;
 import com.cdancy.bitbucket.rest.BitbucketApi;
 import com.cdancy.bitbucket.rest.BitbucketApiMetadata;
 import com.cdancy.bitbucket.rest.domain.common.RequestStatus;
+import com.cdancy.bitbucket.rest.domain.labels.LabelsPage;
 import com.cdancy.bitbucket.rest.domain.repository.MergeConfig;
 import com.cdancy.bitbucket.rest.domain.repository.MergeStrategy;
 import com.cdancy.bitbucket.rest.domain.repository.PermissionsPage;
@@ -59,6 +60,7 @@ public class RepositoryApiMockTest extends BaseBitbucketMockTest {
     private final String permissionsPath = "/permissions/";
     private final String usersPath = permissionsPath + "users";
     private final String groupsPath = permissionsPath + "groups";
+    private final String labelsPath = "/labels";
     private final String settingsPath = "/settings/";
     private final String pullRequestsPath = settingsPath + "pull-requests";
     private final String reposPath = "/repos/";
@@ -834,6 +836,25 @@ public class RepositoryApiMockTest extends BaseBitbucketMockTest {
             final Map<String, ?> queryParams = ImmutableMap.of(limitKeyword, 100, startKeyword, 0);
             assertSent(server, getMethod, restApiPath + BitbucketApiMetadata.API_VERSION
                     + projectsPath + projectKey + reposPath + repoKey + groupsPath, queryParams);
+        } finally {
+            baseApi.close();
+            server.shutdown();
+        }
+    }
+
+    public void testGetLabels() throws Exception {
+        final MockWebServer server = mockWebServer();
+        server.enqueue(new MockResponse().setBody(payloadFromResource("/repository-labels.json")).setResponseCode(200));
+        final BitbucketApi baseApi = api(server.getUrl("/"));
+        final RepositoryApi api = baseApi.repositoryApi();
+        try {
+            final LabelsPage labelsPage = api.getLabels(projectKey, repoKey);
+            assertThat(labelsPage).isNotNull();
+            assertThat(labelsPage.errors()).isEmpty();
+            assertThat(labelsPage.values()).isNotEmpty();
+            assertSent(server,
+                getMethod,
+                restBasePath + BitbucketApiMetadata.API_VERSION + projectsPath + projectKey + reposPath + repoKey + labelsPath);
         } finally {
             baseApi.close();
             server.shutdown();

--- a/src/test/resources/repository-labels.json
+++ b/src/test/resources/repository-labels.json
@@ -1,0 +1,14 @@
+{
+  "size": 2,
+  "limit": 25,
+  "isLastPage": true,
+  "values": [
+    {
+      "name": "label1"
+    },
+    {
+      "name": "label2"
+    }
+  ],
+  "start": 0
+}


### PR DESCRIPTION
closes #316

1. The PR set the missing path annotation as the `com.cdancy.bitbucket.rest.features.ProjectApi#list` defines according [Bitbucket API](https://docs.atlassian.com/bitbucket-server/rest/7.19.2/bitbucket-rest.html#idp149)

2. The PR adds the endpoint for label reading for a dedicated repository. The corresponding MockTest is contained.



