### PR TITLE
Remove grgit and jcenter dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,6 @@ apply from: "$rootDir/gradle/release.gradle"
 
 
 repositories {
-    gradlePluginPortal()
     mavenCentral()
 }
 

--- a/gradle/release.gradle
+++ b/gradle/release.gradle
@@ -1,18 +1,24 @@
 buildscript {
     repositories {
-        gradlePluginPortal()
         mavenCentral()
     }
-
     dependencies {
-        classpath "org.ajoberstar:gradle-git:$depVersions.gradleGit"
+        classpath 'org.eclipse.jgit:org.eclipse.jgit:6.0.0.202111291000-r'
     }
 }
 
-System.setProperty('org.ajoberstar.grgit.auth.username', project.githubUsername)
-System.setProperty('org.ajoberstar.grgit.auth.password', project.githubPassword)
+import org.eclipse.jgit.api.Git
+import org.eclipse.jgit.api.DeleteTagCommand
+import org.eclipse.jgit.api.TagCommand
+import org.eclipse.jgit.api.PushCommand
+import org.eclipse.jgit.lib.Repository
+import org.eclipse.jgit.storage.file.FileRepositoryBuilder
+import org.eclipse.jgit.transport.UsernamePasswordCredentialsProvider
 
-ext.repo = org.ajoberstar.grgit.Grgit.open(rootDir)
+File repoDir = new File("${projectDir}")
+FileRepositoryBuilder builder = new FileRepositoryBuilder()
+Repository repo = builder.findGitDir(repoDir).build()
+Git git = new Git(repo)
 
 task createTag {
     description = 'Creates repository tag with current project version.'
@@ -22,13 +28,12 @@ task createTag {
         logger.quiet "Creating tag '$tagName'."
 
         // Remove potentially existing tag
-        repo.tag.remove(names: [tagName])
+        DeleteTagCommand delTag = git.tagDelete()
+        delTag.setTags(tagName).call()
 
         // Create tag
-        repo.tag.add {
-            name = tagName
-            message = "Version ${project.version}"
-        }
+        TagCommand tag = git.tag()
+        tag.setName(tagName).setMessage("Version ${project.version}").call()
     }
 }
 
@@ -38,9 +43,10 @@ task pushTag {
 
     doLast {
         logger.quiet "Pushing tag '$createTag.tagName' to remote."
-        repo.push {
-            refsOrSpecs = [createTag.tagName]
-        }
+        PushCommand push = git.push()
+        push.add(createTag.tagName)
+        push.setCredentialsProvider(new UsernamePasswordCredentialsProvider(project.githubUsername, project.githubPassword))
+        push.call()
     }
 }
 


### PR DESCRIPTION
Necessity is mother of the invention... jcenter bintray is down right now. I can't postpone this anymore :-)

Eliminate dependency on grgit as its author does not maintain it anymore and it will not be migrated to mavenCentral.
This PR also removes `gradleUpdateCenter()` as this project is not a gradle plugin.

From https://blog.gradle.org/jcenter-shutdown
> You should avoid using the Plugin Portal as a repository, except for Gradle plugin projects.