### PR TITLE
Fix mock tests

### DIFF
--- a/src/main/java/com/cdancy/bitbucket/rest/features/ProjectApi.java
+++ b/src/main/java/com/cdancy/bitbucket/rest/features/ProjectApi.java
@@ -52,9 +52,10 @@ import org.jclouds.rest.annotations.ResponseParser;
 @SuppressWarnings("PMD.AvoidDuplicateLiterals")
 public interface ProjectApi {
 
-    @Named("/api/{jclouds.api-version}/projects/project:create")
+    @Named("/api/{jclouds.api-version}/projects:create")
     @Documentation({"https://developer.atlassian.com/static/rest/bitbucket-server/latest/bitbucket-rest.html#idm45888277995712"})
     @Consumes(MediaType.APPLICATION_JSON)
+    @Path("/api/{jclouds.api-version}/projects")
     @Fallback(BitbucketFallbacks.ProjectOnError.class)
     @POST
     Project create(@BinderParam(BindToJsonPayload.class) CreateProject createProject);

--- a/src/test/java/com/cdancy/bitbucket/rest/BaseBitbucketMockTest.java
+++ b/src/test/java/com/cdancy/bitbucket/rest/BaseBitbucketMockTest.java
@@ -31,6 +31,7 @@ import javax.ws.rs.core.MediaType;
 
 import org.jclouds.Constants;
 import org.jclouds.ContextBuilder;
+import org.jclouds.logging.slf4j.config.SLF4JLoggingModule;
 
 import com.cdancy.bitbucket.rest.config.BitbucketAuthenticationModule;
 
@@ -74,7 +75,7 @@ public class BaseBitbucketMockTest {
         return ContextBuilder.newBuilder(provider)
                 .endpoint(url.toString())
                 .overrides(setupProperties())
-                .modules(Lists.newArrayList(credsModule))
+                .modules(Lists.newArrayList(credsModule, new SLF4JLoggingModule()))
                 .buildApi(BitbucketApi.class);
     }
 

--- a/src/test/java/com/cdancy/bitbucket/rest/features/ProjectApiMockTest.java
+++ b/src/test/java/com/cdancy/bitbucket/rest/features/ProjectApiMockTest.java
@@ -38,7 +38,7 @@ import com.squareup.okhttp.mockwebserver.MockWebServer;
 /**
  * Mock tests for the {@link ProjectApi} class.
  */
-@Test(groups = "unit", testName = "ProjctApiMockTest")
+@Test(groups = "unit", testName = "ProjectApiMockTest")
 public class ProjectApiMockTest extends BaseBitbucketMockTest {
 
     private final String localMethod = "GET";
@@ -516,4 +516,5 @@ public class ProjectApiMockTest extends BaseBitbucketMockTest {
             server.shutdown();
         }
     }
+
 }


### PR DESCRIPTION
This fixes #280.

Three mock tests are currently broken. I identified one problem: a missing ` @Path` in the `ProjectApi`. In this PR:

* Missing `@Path` annotation in `ProjectApi.java`
* Typo in testng `testName`
* Add packet tracing for easier test debugging

There is ONE more bug in SyncApiMockTest that I am still working on #324
