### PR TITLE
ISSUE-334: Add endpoint to edit pull-requests

### DIFF
--- a/src/main/java/com/cdancy/bitbucket/rest/features/PullRequestApi.java
+++ b/src/main/java/com/cdancy/bitbucket/rest/features/PullRequestApi.java
@@ -37,6 +37,7 @@ import com.cdancy.bitbucket.rest.domain.pullrequest.MergeStatus;
 import com.cdancy.bitbucket.rest.domain.pullrequest.PullRequest;
 import com.cdancy.bitbucket.rest.domain.pullrequest.PullRequestPage;
 import com.cdancy.bitbucket.rest.options.CreateParticipants;
+import com.cdancy.bitbucket.rest.options.EditPullRequest;
 import org.jclouds.javax.annotation.Nullable;
 import org.jclouds.rest.annotations.BinderParam;
 import org.jclouds.rest.annotations.Fallback;
@@ -104,6 +105,17 @@ public interface PullRequestApi {
     PullRequest create(@PathParam("project") String project,
                        @PathParam("repo") String repo,
                        @BinderParam(BindToJsonPayload.class) CreatePullRequest createPullRequest);
+
+    @Named("pull-request:edit")
+    @Documentation({"https://developer.atlassian.com/static/rest/bitbucket-server/latest/bitbucket-rest.html#idp304"})
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Path("/{project}/repos/{repo}/pull-requests/{pullRequestId}")
+    @Fallback(PullRequestOnError.class)
+    @PUT
+    PullRequest edit(@PathParam("project") String project,
+                     @PathParam("repo") String repo,
+                     @PathParam("pullRequestId") int pullRequestId,
+                     @BinderParam(BindToJsonPayload.class) EditPullRequest editPullRequest);
 
     @Named("pull-request:delete")
     @Documentation({"https://docs.atlassian.com/bitbucket-server/rest/5.13.0/bitbucket-rest.html?utm_source=%2Fstatic%2Frest%2Fbitbucket-server%2Flatest%2Fbitbucket-rest.html&utm_medium=301#idm46209337261168"})

--- a/src/main/java/com/cdancy/bitbucket/rest/options/EditPullRequest.java
+++ b/src/main/java/com/cdancy/bitbucket/rest/options/EditPullRequest.java
@@ -1,0 +1,37 @@
+package com.cdancy.bitbucket.rest.options;
+
+import com.cdancy.bitbucket.rest.domain.pullrequest.Person;
+import com.google.auto.value.AutoValue;
+import org.jclouds.javax.annotation.Nullable;
+import org.jclouds.json.SerializedNames;
+
+import java.util.List;
+
+@AutoValue
+public abstract class EditPullRequest {
+
+    public abstract int id();
+
+    public abstract int version();
+
+    public abstract String title();
+
+    @Nullable
+    public abstract String description();
+
+    // default to empty List if null
+    @Nullable
+    public abstract List<Person> reviewers();
+
+    EditPullRequest() {
+    }
+
+    @SerializedNames({"id", "version", "title", "description", "reviewers"})
+    public static EditPullRequest create(final int id,
+                                         final int version,
+                                         final String title,
+                                         final String description,
+                                         final List<Person> reviewers) {
+        return new AutoValue_EditPullRequest(id, version, title, description, reviewers);
+    }
+}

--- a/src/test/java/com/cdancy/bitbucket/rest/features/PullRequestApiLiveTest.java
+++ b/src/test/java/com/cdancy/bitbucket/rest/features/PullRequestApiLiveTest.java
@@ -33,6 +33,7 @@ import com.cdancy.bitbucket.rest.domain.common.Reference;
 
 import com.cdancy.bitbucket.rest.options.CreateParticipants;
 import com.cdancy.bitbucket.rest.options.CreatePullRequest;
+import com.cdancy.bitbucket.rest.options.EditPullRequest;
 import com.google.common.collect.Lists;
 import org.jclouds.ContextBuilder;
 import org.testng.annotations.Test;
@@ -109,6 +110,15 @@ public class PullRequestApiLiveTest extends BaseBitbucketApiLiveTest {
         assertThat(repo.equals(pr.fromRef().repository().name())).isTrue();
         prId = pr.id();
         version = pr.version();
+    }
+
+    @Test(dependsOnMethods = "testCreatePullRequest")
+    public void testEditPullRequest() {
+        final PullRequest pr = api().get(project, repo, prId);
+        final EditPullRequest epr = EditPullRequest.create(prId, pr.version(), pr.title(), pr.description() + " [edited]", pr.reviewers());
+        final PullRequest editedPr = api().edit(project, repo, prId, epr);
+        assertThat(editedPr.version()).isEqualTo(pr.version() + 1);
+        assertThat(editedPr.description()).endsWith("[edited]");
     }
 
     @Test


### PR DESCRIPTION
Adds an endpoint for editing pull-request details since this doesn't exist yet.


