### PR TITLE
use Gradle Daemon

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ cache:
 install: true
     
 script:
-  - ./gradlew -s -Dorg.gradle.daemon=false clean build mockTest publishToMavenLocal
+  - ./gradlew -s -Dorg.gradle.daemon=true clean build mockTest publishToMavenLocal
 
 after_script:
   - bash <(curl -s https://codecov.io/bash)


### PR DESCRIPTION
[Gradle daemon](https://docs.gradle.org/current/userguide/gradle_daemon.html#header). The Daemon is a long-lived process that help to avoid the cost of JVM startup for every build. Since Gradle 3.0, Gradle daemon is enabled by default. For an older version, you should enable it by setting `org.gradle.daemon=true`.
