### PR TITLE
Add com.google.code.gson to the public API (JsonElement)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,9 @@ dependencies {
     ext.autoValueVersion = '1.9'
     ext.guiceVersion = '5.1.0'
 
+    // The transitive dependencies that are exposed via the public API of this project
+    api 'com.google.code.gson:gson:2.8.9'
+
     implementation 'javax.xml.bind:jaxb-api:2.3.1'
     implementation 'javax.annotation:javax.annotation-api:1.3.2'
     implementation ("org.apache.jclouds:jclouds-core:${jcloudsVersion}")


### PR DESCRIPTION
This addresses #339 

The API of this project exposes the class `com.google.gson.JsonElement` from the the transitive dependency `com.google.code.gson:gson:2.8.9`. This PR fixes that by declaring that dependency using the `api` configuration. Information about the `api` configuration can be found in Gradle's [The Java Library Plugin](https://docs.gradle.org/current/userguide/java_library_plugin.html)

While preparing this PR, I visually reviewed the API and this is the only one I could see.