### PR TITLE
Add new statuses to `BuildStatusApi`

### DIFF
--- a/src/main/java/com/cdancy/bitbucket/rest/domain/build/Status.java
+++ b/src/main/java/com/cdancy/bitbucket/rest/domain/build/Status.java
@@ -27,7 +27,9 @@ public abstract class Status {
     public enum StatusState {
         SUCCESSFUL,
         FAILED,
-        INPROGRESS
+        INPROGRESS,
+        CANCELLED,
+        UNKNOWN
     }
 
     public abstract long dateAdded();

--- a/src/main/java/com/cdancy/bitbucket/rest/domain/build/Summary.java
+++ b/src/main/java/com/cdancy/bitbucket/rest/domain/build/Summary.java
@@ -23,16 +23,22 @@ import org.jclouds.json.SerializedNames;
 @AutoValue
 public abstract class Summary {
 
+    public abstract long cancelled();
+
     public abstract long failed();
 
     public abstract long inProgress();
 
     public abstract long successful();
 
-    @SerializedNames({"failed", "inProgress", "successful"})
-    public static Summary create(final long failed, 
-            final long inProgress, 
-            final long successful) {
-        return new AutoValue_Summary(failed, inProgress, successful);
+    public abstract long unknown();
+
+    @SerializedNames({"cancelled", "failed", "inProgress", "successful", "unknown"})
+    public static Summary create(final long cancelled,
+            final long failed,
+            final long inProgress,
+            final long successful,
+            final long unknown) {
+        return new AutoValue_Summary(cancelled, failed, inProgress, successful, unknown);
     }
 }

--- a/src/main/java/com/cdancy/bitbucket/rest/options/CreateBuildStatus.java
+++ b/src/main/java/com/cdancy/bitbucket/rest/options/CreateBuildStatus.java
@@ -27,7 +27,9 @@ public abstract class CreateBuildStatus {
     public enum STATE {
         SUCCESSFUL,
         FAILED,
-        INPROGRESS
+        INPROGRESS,
+        CANCELLED,
+        UNKNOWN
     }
 
     public abstract String state();

--- a/src/test/java/com/cdancy/bitbucket/rest/features/BuildStatusApiLiveTest.java
+++ b/src/test/java/com/cdancy/bitbucket/rest/features/BuildStatusApiLiveTest.java
@@ -104,6 +104,8 @@ public class BuildStatusApiLiveTest extends BaseBitbucketApiLiveTest {
         assertThat(summary.successful() == 1).isTrue();
         assertThat(summary.inProgress() == 0).isTrue();
         assertThat(summary.failed() == 0).isTrue();
+        assertThat(summary.cancelled() == 0).isTrue();
+        assertThat(summary.unknown() == 0).isTrue();
     }
     
     @Test
@@ -114,6 +116,8 @@ public class BuildStatusApiLiveTest extends BaseBitbucketApiLiveTest {
         assertThat(summary.successful() == 0).isTrue();
         assertThat(summary.inProgress() == 0).isTrue();
         assertThat(summary.failed() == 0).isTrue();
+        assertThat(summary.cancelled() == 0).isTrue();
+        assertThat(summary.unknown() == 0).isTrue();
     }
 
     @AfterClass

--- a/src/test/java/com/cdancy/bitbucket/rest/features/BuildStatusApiMockTest.java
+++ b/src/test/java/com/cdancy/bitbucket/rest/features/BuildStatusApiMockTest.java
@@ -91,9 +91,11 @@ public class BuildStatusApiMockTest extends BaseBitbucketMockTest {
             
             final Summary summary = baseApi.buildStatusApi().summary(commitHash);
             assertThat(summary).isNotNull();
-            assertThat(summary.failed() == 1).isTrue();
-            assertThat(summary.inProgress() == 2).isTrue();
-            assertThat(summary.successful() == 3).isTrue();
+            assertThat(summary.cancelled() == 1).isTrue();
+            assertThat(summary.failed() == 2).isTrue();
+            assertThat(summary.inProgress() == 3).isTrue();
+            assertThat(summary.successful() == 4).isTrue();
+            assertThat(summary.unknown() == 5).isTrue();
 
             assertSent(server, "GET", restBuildStatusPath + BitbucketApiMetadata.API_VERSION
                     + "/commits/stats/306bcf274566f2e89f75ae6f7faf10beff38382012");

--- a/src/test/resources/branch-list.json
+++ b/src/test/resources/branch-list.json
@@ -37,9 +37,11 @@
           ]
         },
         "com.atlassian.bitbucket.server.bitbucket-build:build-status-metadata": {
+          "cancelled": 0,
           "successful": 1,
           "inProgress": 0,
-          "failed": 0
+          "failed": 0,
+          "unknown": 0
         }
       }
     }

--- a/src/test/resources/build-summary.json
+++ b/src/test/resources/build-summary.json
@@ -1,5 +1,7 @@
 {
-  "failed": 1,
-  "inProgress": 2,
-  "successful": 3
+  "cancelled": 1,
+  "failed": 2,
+  "inProgress": 3,
+  "successful": 4,
+  "unknown": 5
 }


### PR DESCRIPTION
The PR adds the two new build statuses `CANCELLED` and `UNKNOWN` to the `BuildStatusApi`, which have been added with Bitbucket 8.0: https://developer.atlassian.com/server/bitbucket/reference/api-changelog/#bitbucket-server-8-0

The documentation of the affected end-points is available here:

- Get build status for commit: https://developer.atlassian.com/server/bitbucket/rest/v905/api-group-deprecated/#api-build-status-latest-commits-commitid-get
- Create build status for commit: https://developer.atlassian.com/server/bitbucket/rest/v905/api-group-deprecated/#api-build-status-latest-commits-commitid-post
- Get build status statistics for commit: https://developer.atlassian.com/server/bitbucket/rest/v905/api-group-builds-and-deployments/#api-build-status-latest-commits-stats-commitid-get